### PR TITLE
Add four-channel mixer with EQ UI and global limiter routing

### DIFF
--- a/main.scd
+++ b/main.scd
@@ -8,16 +8,18 @@ s.options.numOutputBusChannels = 2;
 s.options.numInputBusChannels = 8;
 s.options.maxNodes = 1024;
 
-
-
 // ======================
-// Routine principale
+// Initialisation
 // ======================
-~mixTick = Routine {
+~bootMixTable = {
+    ("modules/synths.scd").loadRelative;
+    ("modules/ui.scd").loadRelative;
 
+    ~setupAudio.value;
+    ~createUI.value;
 };
 
 // ======================
 // Boot serveur
 // ======================
-s.waitForBoot({ ~mixTick.play(AppClock) });
+s.waitForBoot({ ~bootMixTable.value });

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -1,9 +1,147 @@
 // ================= SynthDef BufferPlayer =================
 
-
 // ================= Limiteur global =================
-SynthDef(\outputLimiter, {|input=0, out=0|
+SynthDef(\outputLimiter, { |input = 0, out = 0|
     var inSig = In.ar(input, 2);
     var limited = Limiter.ar(inSig, 0.99, 0.01);
     Out.ar(out, limited.tanh);
 }).add;
+
+// ================= Mixage et gestion des bus =================
+
+// Définitions des tranches d'entrée : 1 (mono), 3/4, 5/6, 7/8
+~mixInputs = [
+    (label: "1",     channels: [0, 0], isMono: 1),
+    (label: "3 / 4", channels: [2, 3], isMono: 0),
+    (label: "5 / 6", channels: [4, 5], isMono: 0),
+    (label: "7 / 8", channels: [6, 7], isMono: 0)
+];
+
+// SynthDef pour chaque tranche d'entrée
+SynthDef(\mixInputChannel, { |inA = 0, inB = 1, isMono = 0, outBus = 0, gain = 1|
+    var sig;
+    var stereo = SoundIn.ar([inA, inB]);
+    var mono = SoundIn.ar(inA) ! 2;
+    sig = (stereo * (1 - isMono)) + (mono * isMono);
+    Out.ar(outBus, sig * gain);
+}).add;
+
+// SynthDef pour l'égaliseur 4 bandes et le gain maître
+SynthDef(\mixMaster, {
+    |inBus = 0, outBus = 0, masterGain = 1,
+    lowFreq = 120, lowGain = 0,
+    mid1Freq = 500, mid1Gain = 0,
+    mid2Freq = 2000, mid2Gain = 0,
+    highFreq = 8000, highGain = 0|
+    var sig;
+    sig = In.ar(inBus, 2);
+    sig = BLowShelf.ar(sig, lowFreq, 1, lowGain);
+    sig = BPeakEQ.ar(sig, mid1Freq, 1, mid1Gain);
+    sig = BPeakEQ.ar(sig, mid2Freq, 1, mid2Gain);
+    sig = BHiShelf.ar(sig, highFreq, 1, highGain);
+    sig = sig * masterGain;
+    Out.ar(outBus, sig);
+}).add;
+
+// Paramètres d'égalisation par défaut
+~eqDefaults = (
+    low:  (freq: 120,  gain: 0),
+    mid1: (freq: 500,  gain: 0),
+    mid2: (freq: 2000, gain: 0),
+    high: (freq: 8000, gain: 0)
+);
+
+~eqParamMap = (
+    low:  (freqKey: \lowFreq,  gainKey: \lowGain),
+    mid1: (freqKey: \mid1Freq, gainKey: \mid1Gain),
+    mid2: (freqKey: \mid2Freq, gainKey: \mid2Gain),
+    high: (freqKey: \highFreq, gainKey: \highGain)
+);
+
+~setupAudio = {
+    // Nettoyage si nécessaire
+    [~channelSynths, ~mixSynth, ~limiterSynth].do { |item|
+        if(item.notNil) {
+            if(item.isKindOf(Array)) {
+                item.do(_.tryPerform(\free));
+            } {
+                item.tryPerform(\free);
+            };
+        };
+    };
+
+    [~inputGroup, ~processingGroup, ~outputGroup].do(_.tryPerform(\free));
+    [~mixBus, ~postEqBus].do { |bus| bus.tryPerform(\free) };
+
+    ~mixBus = Bus.audio(s, 2);
+    ~postEqBus = Bus.audio(s, 2);
+
+    ~inputGroup = Group.head(s);
+    ~processingGroup = Group.after(~inputGroup);
+    ~outputGroup = Group.after(~processingGroup);
+
+    ~channelSynths = ~mixInputs.collect { |cfg|
+        Synth(\mixInputChannel, [
+            \inA, cfg[\channels][0],
+            \inB, cfg[\channels][1],
+            \isMono, cfg[\isMono],
+            \outBus, ~mixBus,
+            \gain, 1
+        ], target: ~inputGroup);
+    };
+
+    ~eqState = IdentityDictionary.new;
+    ~eqDefaults.keysValuesDo { |band, defaults|
+        ~eqState[band] = defaults.copy;
+    };
+
+    ~masterGainDB = 0;
+
+    ~mixSynth = Synth(\mixMaster, [
+        \inBus, ~mixBus,
+        \outBus, ~postEqBus,
+        \masterGain, ~masterGainDB.dbamp,
+        \lowFreq, ~eqState[\low][\freq],
+        \lowGain, ~eqState[\low][\gain],
+        \mid1Freq, ~eqState[\mid1][\freq],
+        \mid1Gain, ~eqState[\mid1][\gain],
+        \mid2Freq, ~eqState[\mid2][\freq],
+        \mid2Gain, ~eqState[\mid2][\gain],
+        \highFreq, ~eqState[\high][\freq],
+        \highGain, ~eqState[\high][\gain]
+    ], target: ~processingGroup);
+
+    ~limiterSynth = Synth(\outputLimiter, [
+        \input, ~postEqBus,
+        \out, 0
+    ], target: ~outputGroup);
+
+    ~setMasterGain = { |db|
+        ~masterGainDB = db;
+        ~mixSynth.tryPerform(\set, \masterGain, db.dbamp);
+    };
+
+    ~setEqBand = { |band, freq, gain|
+        var params = ~eqParamMap[band];
+        ~eqState[band] = (freq: freq, gain: gain);
+        if(params.notNil) {
+            ~mixSynth.tryPerform(\set, params[\freqKey], freq, params[\gainKey], gain);
+        };
+    };
+
+    ~getEqState = { |band|
+        ~eqState[band] ?? { (freq: 0, gain: 0) };
+    };
+
+    ~getMasterGain = { ~masterGainDB };
+
+    CmdPeriod.doOnce({
+        [~channelSynths, ~mixSynth, ~limiterSynth].do { |item|
+            if(item.notNil) {
+                if(item.isKindOf(Array)) { item.do(_.tryPerform(\free)) } { item.tryPerform(\free) };
+            };
+        };
+        [~mixBus, ~postEqBus].do { |bus| bus.tryPerform(\free) };
+        [~inputGroup, ~processingGroup, ~outputGroup].do(_.tryPerform(\free));
+    });
+};

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -1,18 +1,103 @@
 ~createUI = {
-    var window;
+    var window, masterSlider, masterLabel, masterValueLabel;
+    var eqSpecs, eqControls;
 
-    var applyDarkStyle = { |view|
-        view.background_(Color.black).stringColor_(Color.white);
+    var darkBackground = Color.new255(25, 25, 25);
+    var accentColor = Color.new255(90, 180, 255);
+
+    if(~mixWindow.notNil) { ~mixWindow.close };
+    window = Window("MixTable - 4 entrées", Rect(100, 100, 760, 360));
+    window.background_(darkBackground);
+    ~mixWindow = window;
+
+    masterLabel = StaticText(window)
+        .string_("Gain maître")
+        .align_(\center)
+        .stringColor_(Color.white);
+
+    masterSlider = Slider(window);
+    masterSlider.orientation_(\vertical);
+    masterSlider.background_(Color.gray(0.2));
+
+    masterValueLabel = StaticText(window)
+        .string_("0.0 dB")
+        .align_(\center)
+        .stringColor_(Color.white);
+
+    eqSpecs = [
+        (band: \low,  name: "Low",  freqRange: [40, 250],   gainRange: [-12, 12]),
+        (band: \mid1, name: "Mid 1", freqRange: [250, 1200], gainRange: [-12, 12]),
+        (band: \mid2, name: "Mid 2", freqRange: [1200, 5000], gainRange: [-12, 12]),
+        (band: \high, name: "High", freqRange: [5000, 16000], gainRange: [-12, 12])
+    ];
+
+    eqControls = eqSpecs.collect { |spec|
+        var container = CompositeView(window, Rect(0, 0, 160, 260))
+            .background_(Color.gray(0.12))
+            .border_(Color.gray(0.35), 1);
+        var title = StaticText(container)
+            .string_(spec[\name])
+            .align_(\center)
+            .stringColor_(Color.white)
+            .minHeight_(24);
+        var valueLabel = StaticText(container)
+            .string_("" )
+            .align_(\center)
+            .stringColor_(accentColor)
+            .minHeight_(36);
+        var slider = Slider2D(container)
+            .background_(Color.gray(0.18))
+            .knobColor_(accentColor);
+
+        container.layout_(VLayout(6,
+            [title, 0],
+            [slider, 1],
+            [valueLabel, 0]
+        ).margins_(10));
+
+        slider.action = { |view|
+            var freq = view.x.linexp(0, 1, spec[\freqRange][0], spec[\freqRange][1]);
+            var gain = view.y.linlin(0, 1, spec[\gainRange][0], spec[\gainRange][1]);
+            var display = freq.round(1).asString ++ " Hz\n" ++ gain.round(0.1).asString ++ " dB";
+            valueLabel.string_(display);
+            ~setEqBand.value(spec[\band], freq, gain);
+        };
+
+        (container: container, slider: slider, valueLabel: valueLabel, spec: spec);
     };
 
+    window.layout_(HLayout(12,
+        VLayout(8,
+            [masterLabel, 0],
+            [masterSlider, 1],
+            [masterValueLabel, 0]
+        ).margins_(12),
+        HLayout(12, *eqControls.collect(_.container))
+    ).margins_(12));
 
+    {
+        var masterDB = ~getMasterGain.value;
+        var sliderValue = masterDB.linlin(0, 12, 0, 1).clip(0, 1);
+        masterSlider.value_(sliderValue);
+        masterValueLabel.string_(masterDB.round(0.1).asString ++ " dB");
+    }.value;
 
-    // --- Layout ---
-    window.layout_(
-    )
+    masterSlider.action = { |sl|
+        var db = sl.value.linlin(0, 1, 0, 12);
+        masterValueLabel.string_(db.round(0.1).asString ++ " dB");
+        ~setMasterGain.value(db);
+    };
 
-    window.onClose = { window.close; freqscope.kill };
+    eqControls.do { |control|
+        var spec = control[\spec];
+        var state = ~getEqState.value(spec[\band]);
+        var x = state[\freq].linexp(spec[\freqRange][0], spec[\freqRange][1], 0, 1).clip(0, 1);
+        var y = state[\gain].linlin(spec[\gainRange][0], spec[\gainRange][1], 0, 1).clip(0, 1);
+        control[\slider].setXY(x, y);
+        control[\valueLabel].string_(state[\freq].round(1).asString ++ " Hz\n" ++ state[\gain].round(0.1).asString ++ " dB");
+    };
+
+    window.onClose = { ~mixWindow = nil; window.close };
     window.front;
 };
 
-~createUI.value;


### PR DESCRIPTION
## Summary
- add audio setup helpers to build four input strips feeding a shared EQ stage and limiter
- define a four-band EQ master synth with master gain control routed into the global limiter
- create a SuperCollider UI with a master gain slider and four XY sliders to drive the EQ bands

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68da62885cc88333aa8caf06b98a2866