### PR TITLE
Add four-channel mixer with per-strip EQ UI and limiter routing

### DIFF
--- a/main.scd
+++ b/main.scd
@@ -8,16 +8,18 @@ s.options.numOutputBusChannels = 2;
 s.options.numInputBusChannels = 8;
 s.options.maxNodes = 1024;
 
-
-
 // ======================
-// Routine principale
+// Initialisation
 // ======================
-~mixTick = Routine {
+~bootMixTable = {
+    ("modules/synths.scd").loadRelative;
+    ("modules/ui.scd").loadRelative;
 
+    ~setupAudio.value;
+    ~createUI.value;
 };
 
 // ======================
 // Boot serveur
 // ======================
-s.waitForBoot({ ~mixTick.play(AppClock) });
+s.waitForBoot({ ~bootMixTable.value });

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -1,9 +1,155 @@
 // ================= SynthDef BufferPlayer =================
 
-
 // ================= Limiteur global =================
-SynthDef(\outputLimiter, {|input=0, out=0|
+SynthDef(\outputLimiter, { |input = 0, out = 0|
     var inSig = In.ar(input, 2);
     var limited = Limiter.ar(inSig, 0.99, 0.01);
     Out.ar(out, limited.tanh);
 }).add;
+
+// ================= Mixage et gestion des bus =================
+
+// Définitions des tranches d'entrée : 1 (mono), 3/4, 5/6, 7/8
+~mixInputs = [
+    (label: "1",     channels: [0, 0], isMono: 1),
+    (label: "3 / 4", channels: [2, 3], isMono: 0),
+    (label: "5 / 6", channels: [4, 5], isMono: 0),
+    (label: "7 / 8", channels: [6, 7], isMono: 0)
+];
+
+// SynthDef pour chaque tranche d'entrée avec égaliseur 4 bandes
+SynthDef(\mixInputChannel, {
+    |inA = 0, inB = 1, isMono = 0, outBus = 0, gain = 1,
+    lowFreq = 120, lowGain = 0,
+    mid1Freq = 500, mid1Gain = 0,
+    mid2Freq = 2000, mid2Gain = 0,
+    highFreq = 8000, highGain = 0|
+    var sig;
+    var stereo = SoundIn.ar([inA, inB]);
+    var mono = SoundIn.ar(inA) ! 2;
+    sig = (stereo * (1 - isMono)) + (mono * isMono);
+    sig = BLowShelf.ar(sig, lowFreq, 1, lowGain);
+    sig = BPeakEQ.ar(sig, mid1Freq, 1, mid1Gain);
+    sig = BPeakEQ.ar(sig, mid2Freq, 1, mid2Gain);
+    sig = BHiShelf.ar(sig, highFreq, 1, highGain);
+    Out.ar(outBus, sig * gain);
+}).add;
+
+// SynthDef pour le gain maître
+SynthDef(\mixMaster, { |inBus = 0, outBus = 0, masterGain = 1|
+    var sig = In.ar(inBus, 2);
+    Out.ar(outBus, sig * masterGain);
+}).add;
+
+// Paramètres d'égalisation par défaut
+~eqDefaults = (
+    low:  (freq: 120,  gain: 0),
+    mid1: (freq: 500,  gain: 0),
+    mid2: (freq: 2000, gain: 0),
+    high: (freq: 8000, gain: 0)
+);
+
+~eqParamMap = (
+    low:  (freqKey: \lowFreq,  gainKey: \lowGain),
+    mid1: (freqKey: \mid1Freq, gainKey: \mid1Gain),
+    mid2: (freqKey: \mid2Freq, gainKey: \mid2Gain),
+    high: (freqKey: \highFreq, gainKey: \highGain)
+);
+
+~setupAudio = {
+    // Nettoyage si nécessaire
+    [~channelSynths, ~mixSynth, ~limiterSynth].do { |item|
+        if(item.notNil) {
+            if(item.isKindOf(Array)) {
+                item.do(_.tryPerform(\free));
+            } {
+                item.tryPerform(\free);
+            };
+        };
+    };
+
+    [~inputGroup, ~processingGroup, ~outputGroup].do(_.tryPerform(\free));
+    [~mixBus, ~postEqBus].do { |bus| bus.tryPerform(\free) };
+
+    ~channelStates = nil;
+
+    ~mixBus = Bus.audio(s, 2);
+    ~postEqBus = Bus.audio(s, 2);
+
+    ~inputGroup = Group.head(s);
+    ~processingGroup = Group.after(~inputGroup);
+    ~outputGroup = Group.after(~processingGroup);
+
+    ~channelStates = Array.newClear(~mixInputs.size);
+
+    ~channelSynths = ~mixInputs.collect { |cfg, index|
+        var args = [
+            \inA, cfg[\channels][0],
+            \inB, cfg[\channels][1],
+            \isMono, cfg[\isMono],
+            \outBus, ~mixBus,
+            \gain, 1
+        ];
+        var eqState = IdentityDictionary.new;
+        ~eqDefaults.keysValuesDo { |band, defaults|
+            var params = ~eqParamMap[band];
+            eqState[band] = defaults.copy;
+            args = args ++ [
+                params[\freqKey], defaults[\freq],
+                params[\gainKey], defaults[\gain]
+            ];
+        };
+        ~channelStates[index] = eqState;
+        Synth(\mixInputChannel, args, target: ~inputGroup);
+    };
+
+    ~masterGainDB = 0;
+
+    ~mixSynth = Synth(\mixMaster, [
+        \inBus, ~mixBus,
+        \outBus, ~postEqBus,
+        \masterGain, ~masterGainDB.dbamp
+    ], target: ~processingGroup);
+
+    ~limiterSynth = Synth(\outputLimiter, [
+        \input, ~postEqBus,
+        \out, 0
+    ], target: ~outputGroup);
+
+    ~setMasterGain = { |db|
+        ~masterGainDB = db;
+        ~mixSynth.tryPerform(\set, \masterGain, db.dbamp);
+    };
+
+    ~setChannelEq = { |channelIndex, band, freq, gain|
+        var params = ~eqParamMap[band];
+        var channelState = ~channelStates.tryPerform(\at, channelIndex);
+        var channelSynth = ~channelSynths.tryPerform(\at, channelIndex);
+        if(params.notNil and: { channelState.notNil } and: { channelSynth.notNil }) {
+            channelState[band] = (freq: freq, gain: gain);
+            channelSynth.tryPerform(\set, params[\freqKey], freq, params[\gainKey], gain);
+        };
+    };
+
+    ~getChannelEq = { |channelIndex, band|
+        var channelState = ~channelStates.tryPerform(\at, channelIndex);
+        if(channelState.notNil) {
+            (channelState[band] ?? { ~eqDefaults[band] }).copy
+        } {
+            ~eqDefaults[band].copy
+        };
+    };
+
+    ~getMasterGain = { ~masterGainDB };
+
+    CmdPeriod.doOnce({
+        [~channelSynths, ~mixSynth, ~limiterSynth].do { |item|
+            if(item.notNil) {
+                if(item.isKindOf(Array)) { item.do(_.tryPerform(\free)) } { item.tryPerform(\free) };
+            };
+        };
+        [~mixBus, ~postEqBus].do { |bus| bus.tryPerform(\free) };
+        [~inputGroup, ~processingGroup, ~outputGroup].do(_.tryPerform(\free));
+        ~channelStates = nil;
+    });
+};

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -1,18 +1,124 @@
 ~createUI = {
-    var window;
+    var window, masterSlider, masterLabel, masterValueLabel;
+    var eqSpecs, channelViews, inputs;
 
-    var applyDarkStyle = { |view|
-        view.background_(Color.black).stringColor_(Color.white);
+    var darkBackground = Color.new255(25, 25, 25);
+    var accentColor = Color.new255(90, 180, 255);
+
+    if(~mixWindow.notNil) { ~mixWindow.close };
+    window = Window("MixTable - 4 entrées", Rect(100, 100, 1100, 520));
+    window.background_(darkBackground);
+    ~mixWindow = window;
+
+    masterLabel = StaticText(window)
+        .string_("Gain maître")
+        .align_(\center)
+        .stringColor_(Color.white);
+
+    masterSlider = Slider(window);
+    masterSlider.orientation_(\vertical);
+    masterSlider.background_(Color.gray(0.2));
+
+    masterValueLabel = StaticText(window)
+        .string_("0.0 dB")
+        .align_(\center)
+        .stringColor_(Color.white);
+
+    eqSpecs = [
+        (band: \low,  name: "Low",  freqRange: [40, 250],   gainRange: [-60, 20]),
+        (band: \mid1, name: "Mid 1", freqRange: [250, 1200], gainRange: [-60, 20]),
+        (band: \mid2, name: "Mid 2", freqRange: [1200, 5000], gainRange: [-60, 20]),
+        (band: \high, name: "High", freqRange: [5000, 16000], gainRange: [-60, 20])
+    ];
+
+    inputs = ~mixInputs ?? { [] };
+
+    channelViews = inputs.collect { |cfg, index|
+        var channelContainer = CompositeView(window, Rect(0, 0, 240, 460))
+            .background_(Color.gray(0.12))
+            .border_(Color.gray(0.35), 1);
+        var channelLabel = StaticText(channelContainer)
+            .string_("Entrée " ++ cfg[\label])
+            .align_(\center)
+            .stringColor_(Color.white)
+            .minHeight_(28);
+        var eqControls = eqSpecs.collect { |spec|
+            var container = CompositeView(channelContainer, Rect(0, 0, 200, 100))
+                .background_(Color.gray(0.16))
+                .border_(Color.gray(0.3), 1);
+            var title = StaticText(container)
+                .string_(spec[\name])
+                .align_(\center)
+                .stringColor_(Color.white)
+                .minHeight_(20);
+            var valueLabel = StaticText(container)
+                .string_("")
+                .align_(\center)
+                .stringColor_(accentColor)
+                .minHeight_(40);
+            var slider = Slider2D(container)
+                .background_(Color.gray(0.18))
+                .knobColor_(accentColor);
+
+            container.layout_(VLayout(6,
+                [title, 0],
+                [slider, 1],
+                [valueLabel, 0]
+            ).margins_(10));
+
+            slider.action = { |view|
+                var freq = view.x.linexp(0, 1, spec[\freqRange][0], spec[\freqRange][1]);
+                var gain = view.y.linlin(0, 1, spec[\gainRange][0], spec[\gainRange][1]);
+                var display = freq.round(1).asString ++ " Hz\n" ++ gain.round(0.1).asString ++ " dB";
+                valueLabel.string_(display);
+                ~setChannelEq.value(index, spec[\band], freq, gain);
+            };
+
+            (container: container, slider: slider, valueLabel: valueLabel, spec: spec);
+        };
+
+        channelContainer.layout_(VLayout(10,
+            *([[channelLabel, 0]] ++ eqControls.collect { |control| [control[\container], 1] })
+        ).margins_(12));
+
+        (container: channelContainer, eqControls: eqControls);
     };
 
+    window.layout_(HLayout(12,
+        VLayout(8,
+            [masterLabel, 0],
+            [masterSlider, 1],
+            [masterValueLabel, 0]
+        ).margins_(12),
+        HLayout(12, *(channelViews.collect { |view| view[\container] }))
+    ).margins_(12));
 
+    {
+        var masterDB = ~getMasterGain.value;
+        var sliderValue = masterDB.linlin(0, 12, 0, 1).clip(0, 1);
+        masterSlider.value_(sliderValue);
+        masterValueLabel.string_(masterDB.round(0.1).asString ++ " dB");
+    }.value;
 
-    // --- Layout ---
-    window.layout_(
-    )
+    masterSlider.action = { |sl|
+        var db = sl.value.linlin(0, 1, 0, 12);
+        masterValueLabel.string_(db.round(0.1).asString ++ " dB");
+        ~setMasterGain.value(db);
+    };
 
-    window.onClose = { window.close; freqscope.kill };
+    channelViews.do { |channelControl, index|
+        channelControl[\eqControls].do { |control|
+            var spec = control[\spec];
+            var state = ~getChannelEq.value(index, spec[\band]);
+            var x = state[\freq].explin(spec[\freqRange][0], spec[\freqRange][1], 0, 1).clip(0, 1);
+            var y = state[\gain].linlin(spec[\gainRange][0], spec[\gainRange][1], 0, 1).clip(0, 1);
+            control[\slider].x_(x);
+            control[\slider].y_(y);
+            control[\valueLabel].string_(state[\freq].round(1).asString ++ " Hz\n" ++ state[\gain].round(0.1).asString ++ " dB");
+        };
+    };
+
+    window.onClose = { ~mixWindow = nil; window.close };
     window.front;
 };
 
-~createUI.value;


### PR DESCRIPTION
## Summary
- add audio setup helpers to build four input strips feeding per-channel EQ stages and the limiter
- embed the four-band EQ directly inside each input strip while keeping a master gain stage into the global limiter
- expand the SuperCollider UI with the master gain slider and per-channel XY EQ pads offering -60 to +20 dB control per band

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68da62885cc88333aa8caf06b98a2866