### PR TITLE
Add four-channel mixer strips with per-band EQ controls

### DIFF
--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -17,29 +17,23 @@ SynthDef(\outputLimiter, { |input = 0, out = 0|
     (label: "7 / 8", channels: [6, 7], isMono: 0)
 ];
 
-// SynthDef pour chaque tranche d'entrée
-SynthDef(\mixInputChannel, { |inA = 0, inB = 1, isMono = 0, outBus = 0, gain = 1|
-    var sig;
-    var stereo = SoundIn.ar([inA, inB]);
-    var mono = SoundIn.ar(inA) ! 2;
-    sig = (stereo * (1 - isMono)) + (mono * isMono);
-    Out.ar(outBus, sig * gain);
-}).add;
-
-// SynthDef pour l'égaliseur 4 bandes et le gain maître
-SynthDef(\mixMaster, {
-    |inBus = 0, outBus = 0, masterGain = 1,
+// SynthDef pour chaque tranche d'entrée avec égalisation 4 bandes
+SynthDef(\mixChannel, {
+    |inA = 0, inB = 1, isMono = 0, outBus = 0,
+    gainAmp = 1,
     lowFreq = 120, lowGain = 0,
     mid1Freq = 500, mid1Gain = 0,
     mid2Freq = 2000, mid2Gain = 0,
     highFreq = 8000, highGain = 0|
-    var sig;
-    sig = In.ar(inBus, 2);
+    var stereo, mono, sig;
+    stereo = SoundIn.ar([inA, inB]);
+    mono = SoundIn.ar(inA) ! 2;
+    sig = (stereo * (1 - isMono)) + (mono * isMono);
     sig = BLowShelf.ar(sig, lowFreq, 1, lowGain);
     sig = BPeakEQ.ar(sig, mid1Freq, 1, mid1Gain);
     sig = BPeakEQ.ar(sig, mid2Freq, 1, mid2Gain);
     sig = BHiShelf.ar(sig, highFreq, 1, highGain);
-    sig = sig * masterGain;
+    sig = sig * gainAmp;
     Out.ar(outBus, sig);
 }).add;
 
@@ -60,7 +54,7 @@ SynthDef(\mixMaster, {
 
 ~setupAudio = {
     // Nettoyage si nécessaire
-    [~channelSynths, ~mixSynth, ~limiterSynth].do { |item|
+    [~channelSynths, ~limiterSynth].do { |item|
         if(item.notNil) {
             if(item.isKindOf(Array)) {
                 item.do(_.tryPerform(\free));
@@ -70,78 +64,82 @@ SynthDef(\mixMaster, {
         };
     };
 
-    [~inputGroup, ~processingGroup, ~outputGroup].do(_.tryPerform(\free));
-    [~mixBus, ~postEqBus].do { |bus| bus.tryPerform(\free) };
+    [~inputGroup, ~outputGroup].do(_.tryPerform(\free));
+    ~mixBus.tryPerform(\free);
 
     ~mixBus = Bus.audio(s, 2);
-    ~postEqBus = Bus.audio(s, 2);
 
     ~inputGroup = Group.head(s);
-    ~processingGroup = Group.after(~inputGroup);
-    ~outputGroup = Group.after(~processingGroup);
+    ~outputGroup = Group.after(~inputGroup);
 
-    ~channelSynths = ~mixInputs.collect { |cfg|
-        Synth(\mixInputChannel, [
+    ~channelStates = Array.fill(~mixInputs.size, {
+        var eqState = IdentityDictionary.new;
+        ~eqDefaults.keysValuesDo { |band, defaults|
+            eqState[band] = defaults.copy;
+        };
+        (gainDB: 0, eq: eqState);
+    });
+
+    ~channelSynths = ~mixInputs.collect { |cfg, index|
+        var state = ~channelStates[index];
+        Synth(\mixChannel, [
             \inA, cfg[\channels][0],
             \inB, cfg[\channels][1],
             \isMono, cfg[\isMono],
             \outBus, ~mixBus,
-            \gain, 1
+            \gainAmp, state[\gainDB].dbamp,
+            \lowFreq, state[\eq][\low][\freq],
+            \lowGain, state[\eq][\low][\gain],
+            \mid1Freq, state[\eq][\mid1][\freq],
+            \mid1Gain, state[\eq][\mid1][\gain],
+            \mid2Freq, state[\eq][\mid2][\freq],
+            \mid2Gain, state[\eq][\mid2][\gain],
+            \highFreq, state[\eq][\high][\freq],
+            \highGain, state[\eq][\high][\gain]
         ], target: ~inputGroup);
     };
 
-    ~eqState = IdentityDictionary.new;
-    ~eqDefaults.keysValuesDo { |band, defaults|
-        ~eqState[band] = defaults.copy;
-    };
-
-    ~masterGainDB = 0;
-
-    ~mixSynth = Synth(\mixMaster, [
-        \inBus, ~mixBus,
-        \outBus, ~postEqBus,
-        \masterGain, ~masterGainDB.dbamp,
-        \lowFreq, ~eqState[\low][\freq],
-        \lowGain, ~eqState[\low][\gain],
-        \mid1Freq, ~eqState[\mid1][\freq],
-        \mid1Gain, ~eqState[\mid1][\gain],
-        \mid2Freq, ~eqState[\mid2][\freq],
-        \mid2Gain, ~eqState[\mid2][\gain],
-        \highFreq, ~eqState[\high][\freq],
-        \highGain, ~eqState[\high][\gain]
-    ], target: ~processingGroup);
-
     ~limiterSynth = Synth(\outputLimiter, [
-        \input, ~postEqBus,
+        \input, ~mixBus,
         \out, 0
     ], target: ~outputGroup);
 
-    ~setMasterGain = { |db|
-        ~masterGainDB = db;
-        ~mixSynth.tryPerform(\set, \masterGain, db.dbamp);
-    };
-
-    ~setEqBand = { |band, freq, gain|
-        var params = ~eqParamMap[band];
-        ~eqState[band] = (freq: freq, gain: gain);
-        if(params.notNil) {
-            ~mixSynth.tryPerform(\set, params[\freqKey], freq, params[\gainKey], gain);
+    ~setChannelGain = { |index, db|
+        if((index >= 0) and: { index < ~channelSynths.size }) {
+            var synth = ~channelSynths[index];
+            ~channelStates[index][\gainDB] = db;
+            synth.tryPerform(\set, \gainAmp, db.dbamp);
         };
     };
 
-    ~getEqState = { |band|
-        ~eqState[band] ?? { (freq: 0, gain: 0) };
+    ~setChannelEq = { |index, band, freq, gain|
+        if((index >= 0) and: { index < ~channelSynths.size }) {
+            var params = ~eqParamMap[band];
+            var synth = ~channelSynths[index];
+            if(params.notNil) {
+                synth.tryPerform(\set, params[\freqKey], freq, params[\gainKey], gain);
+            };
+            ~channelStates[index][\eq][band] = (freq: freq, gain: gain);
+        };
     };
 
-    ~getMasterGain = { ~masterGainDB };
+    ~getChannelState = { |index|
+        ~channelStates[index] ?? {
+            var eqState = IdentityDictionary.new;
+            ~eqDefaults.keysValuesDo { |band, defaults|
+                eqState[band] = defaults.copy;
+            };
+            (gainDB: 0, eq: eqState);
+        };
+    };
 
     CmdPeriod.doOnce({
-        [~channelSynths, ~mixSynth, ~limiterSynth].do { |item|
+        [~channelSynths, ~limiterSynth].do { |item|
             if(item.notNil) {
                 if(item.isKindOf(Array)) { item.do(_.tryPerform(\free)) } { item.tryPerform(\free) };
             };
         };
-        [~mixBus, ~postEqBus].do { |bus| bus.tryPerform(\free) };
-        [~inputGroup, ~processingGroup, ~outputGroup].do(_.tryPerform(\free));
+        [~mixBus].do { |bus| bus.tryPerform(\free) };
+        [~inputGroup, ~outputGroup].do(_.tryPerform(\free));
     });
 };

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -1,103 +1,132 @@
 ~createUI = {
-    var window, masterSlider, masterLabel, masterValueLabel;
-    var eqSpecs, eqControls;
-
+    var window, channelViews;
     var darkBackground = Color.new255(25, 25, 25);
     var accentColor = Color.new255(90, 180, 255);
+    var textColor = Color.white;
 
-    if(~mixWindow.notNil) { ~mixWindow.close };
-    window = Window("MixTable - 4 entrées", Rect(100, 100, 760, 360));
-    window.background_(darkBackground);
-    ~mixWindow = window;
-
-    masterLabel = StaticText(window)
-        .string_("Gain maître")
-        .align_(\center)
-        .stringColor_(Color.white);
-
-    masterSlider = Slider(window);
-    masterSlider.orientation_(\vertical);
-    masterSlider.background_(Color.gray(0.2));
-
-    masterValueLabel = StaticText(window)
-        .string_("0.0 dB")
-        .align_(\center)
-        .stringColor_(Color.white);
-
-    eqSpecs = [
+    var eqSpecs = [
         (band: \low,  name: "Low",  freqRange: [40, 250],   gainRange: [-12, 12]),
         (band: \mid1, name: "Mid 1", freqRange: [250, 1200], gainRange: [-12, 12]),
         (band: \mid2, name: "Mid 2", freqRange: [1200, 5000], gainRange: [-12, 12]),
         (band: \high, name: "High", freqRange: [5000, 16000], gainRange: [-12, 12])
     ];
 
-    eqControls = eqSpecs.collect { |spec|
-        var container = CompositeView(window, Rect(0, 0, 160, 260))
+    if(~mixWindow.notNil) { ~mixWindow.close };
+    window = Window("MixTable - 4 voies", Rect(100, 100, 1080, 440));
+    window.background_(darkBackground);
+    ~mixWindow = window;
+
+    channelViews = ~mixInputs.collect { |cfg, index|
+        var channelContainer = CompositeView(window)
             .background_(Color.gray(0.12))
-            .border_(Color.gray(0.35), 1);
-        var title = StaticText(container)
-            .string_(spec[\name])
+            .border_(Color.gray(0.35), 1)
+            .minWidth_(240);
+        var title = StaticText(channelContainer)
+            .string_("Tranche " ++ cfg[\label])
             .align_(\center)
-            .stringColor_(Color.white)
+            .stringColor_(textColor)
             .minHeight_(24);
-        var valueLabel = StaticText(container)
-            .string_("" )
+        var gainLabel = StaticText(channelContainer)
+            .string_("Gain")
+            .align_(\center)
+            .stringColor_(textColor);
+        var gainSlider = Slider(channelContainer)
+            .orientation_(\vertical)
+            .background_(Color.gray(0.2))
+            .minHeight_(160);
+        var gainValueLabel = StaticText(channelContainer)
+            .string_("0.0 dB")
             .align_(\center)
             .stringColor_(accentColor)
-            .minHeight_(36);
-        var slider = Slider2D(container)
-            .background_(Color.gray(0.18))
-            .knobColor_(accentColor);
+            .minHeight_(24);
+        var eqTitle = StaticText(channelContainer)
+            .string_("Égalisation")
+            .align_(\center)
+            .stringColor_(textColor)
+            .minHeight_(24);
+        var eqArea = CompositeView(channelContainer)
+            .background_(Color.gray(0.16))
+            .border_(Color.gray(0.25), 1);
 
-        container.layout_(VLayout(6,
-            [title, 0],
-            [slider, 1],
-            [valueLabel, 0]
-        ).margins_(10));
+        var eqControls = eqSpecs.collect { |spec|
+            var eqContainer = CompositeView(eqArea)
+                .background_(Color.gray(0.18))
+                .border_(Color.gray(0.3), 1);
+            var eqName = StaticText(eqContainer)
+                .string_(spec[\name])
+                .align_(\center)
+                .stringColor_(textColor)
+                .minHeight_(20);
+            var eqSlider = Slider2D(eqContainer)
+                .background_(Color.gray(0.1))
+                .knobColor_(accentColor)
+                .minHeight_(110);
+            var eqValueLabel = StaticText(eqContainer)
+                .string_("")
+                .align_(\center)
+                .stringColor_(accentColor)
+                .minHeight_(36);
 
-        slider.action = { |view|
-            var freq = view.x.linexp(0, 1, spec[\freqRange][0], spec[\freqRange][1]);
-            var gain = view.y.linlin(0, 1, spec[\gainRange][0], spec[\gainRange][1]);
-            var display = freq.round(1).asString ++ " Hz\n" ++ gain.round(0.1).asString ++ " dB";
-            valueLabel.string_(display);
-            ~setEqBand.value(spec[\band], freq, gain);
+            eqContainer.layout_(VLayout(6,
+                [eqName, 0],
+                [eqSlider, 1],
+                [eqValueLabel, 0]
+            ).margins_(8));
+
+            eqSlider.action = { |view|
+                var freq = view.x.linexp(0, 1, spec[\freqRange][0], spec[\freqRange][1]);
+                var gain = view.y.linlin(0, 1, spec[\gainRange][0], spec[\gainRange][1]);
+                var display = freq.round(1).asString ++ " Hz\n" ++ gain.round(0.1).asString ++ " dB";
+                eqValueLabel.string_(display);
+                ~setChannelEq.value(index, spec[\band], freq, gain);
+            };
+
+            (container: eqContainer, slider: eqSlider, valueLabel: eqValueLabel, spec: spec);
         };
 
-        (container: container, slider: slider, valueLabel: valueLabel, spec: spec);
+        eqArea.layout_(VLayout(10, *(eqControls.collect { |control|
+            [control[\container], 1]
+        })).margins_(10));
+
+        channelContainer.layout_(VLayout(12,
+            [title, 0],
+            [gainLabel, 0],
+            [gainSlider, 1],
+            [gainValueLabel, 0],
+            [eqTitle, 0],
+            [eqArea, 2]
+        ).margins_(12));
+
+        {
+            var state = ~getChannelState.value(index);
+            var gainDB = state[\gainDB] ?? { 0 };
+            var sliderValue = gainDB.linlin(-60, 20, 0, 1).clip(0, 1);
+            gainSlider.value_(sliderValue);
+            gainValueLabel.string_(gainDB.round(0.1).asString ++ " dB");
+
+            gainSlider.action = { |sl|
+                var db = sl.value.linlin(0, 1, -60, 20);
+                gainValueLabel.string_(db.round(0.1).asString ++ " dB");
+                ~setChannelGain.value(index, db);
+            };
+
+            eqControls.do { |control|
+                var spec = control[\spec];
+                var eqState = state[\eq][spec[\band]] ?? { ~eqDefaults[spec[\band]].copy };
+                var x = eqState[\freq].linexp(spec[\freqRange][0], spec[\freqRange][1], 0, 1).clip(0, 1);
+                var y = eqState[\gain].linlin(spec[\gainRange][0], spec[\gainRange][1], 0, 1).clip(0, 1);
+                control[\slider].setXY(x, y);
+                control[\valueLabel].string_(eqState[\freq].round(1).asString ++ " Hz\n" ++ eqState[\gain].round(0.1).asString ++ " dB");
+            };
+        }.value;
+
+        (container: channelContainer);
     };
 
-    window.layout_(HLayout(12,
-        VLayout(8,
-            [masterLabel, 0],
-            [masterSlider, 1],
-            [masterValueLabel, 0]
-        ).margins_(12),
-        HLayout(12, *eqControls.collect(_.container))
-    ).margins_(12));
-
-    {
-        var masterDB = ~getMasterGain.value;
-        var sliderValue = masterDB.linlin(0, 12, 0, 1).clip(0, 1);
-        masterSlider.value_(sliderValue);
-        masterValueLabel.string_(masterDB.round(0.1).asString ++ " dB");
-    }.value;
-
-    masterSlider.action = { |sl|
-        var db = sl.value.linlin(0, 1, 0, 12);
-        masterValueLabel.string_(db.round(0.1).asString ++ " dB");
-        ~setMasterGain.value(db);
-    };
-
-    eqControls.do { |control|
-        var spec = control[\spec];
-        var state = ~getEqState.value(spec[\band]);
-        var x = state[\freq].linexp(spec[\freqRange][0], spec[\freqRange][1], 0, 1).clip(0, 1);
-        var y = state[\gain].linlin(spec[\gainRange][0], spec[\gainRange][1], 0, 1).clip(0, 1);
-        control[\slider].setXY(x, y);
-        control[\valueLabel].string_(state[\freq].round(1).asString ++ " Hz\n" ++ state[\gain].round(0.1).asString ++ " dB");
-    };
+    window.layout_(HLayout(12, *(channelViews.collect { |control|
+        control[\container]
+    })).margins_(12));
 
     window.onClose = { ~mixWindow = nil; window.close };
     window.front;
 };
-


### PR DESCRIPTION
## Summary
- add dedicated mixer synth with four-band EQ and gain control for each input channel
- sum channel strips to a shared bus processed by the existing limiter
- redesign the UI to present four channel strips with gain faders and per-band EQ editors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da6ba20be883338ca2a0f0124c6c84