### PR TITLE
Adjust EQ gain range to -60..20 dB

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -5,10 +5,10 @@
     var textColor = Color.white;
 
     var eqSpecs = [
-        (band: \low,  name: "Low",  freqRange: [40, 250],   gainRange: [-12, 12]),
-        (band: \mid1, name: "Mid 1", freqRange: [250, 1200], gainRange: [-12, 12]),
-        (band: \mid2, name: "Mid 2", freqRange: [1200, 5000], gainRange: [-12, 12]),
-        (band: \high, name: "High", freqRange: [5000, 16000], gainRange: [-12, 12])
+        (band: \low,  name: "Low",  freqRange: [40, 250],   gainRange: [-60, 20]),
+        (band: \mid1, name: "Mid 1", freqRange: [250, 1200], gainRange: [-60, 20]),
+        (band: \mid2, name: "Mid 2", freqRange: [1200, 5000], gainRange: [-60, 20]),
+        (band: \high, name: "High", freqRange: [5000, 16000], gainRange: [-60, 20])
     ];
 
     if(~mixWindow.notNil) { ~mixWindow.close };


### PR DESCRIPTION
## Summary
- update each EQ band definition to use an XY fader range of -60 to +20 dB while keeping existing frequency spans

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da6d920bdc8333b4de6d52f2fc389d