### PR TITLE
Ensure synthdefs are ready before building UI

### DIFF
--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -67,6 +67,10 @@ SynthDef(\mixChannel, {
     [~inputGroup, ~outputGroup].do(_.tryPerform(\free));
     ~mixBus.tryPerform(\free);
 
+    // S'assurer que toutes les définitions de synthés précédemment envoyées
+    // ont bien été traitées par le serveur avant d'instancier de nouveaux nodes.
+    s.sync;
+
     ~mixBus = Bus.audio(s, 2);
 
     ~inputGroup = Group.head(s);

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -22,7 +22,13 @@
 
     if(~mixWindow.notNil) { ~mixWindow.close };
     window = Window("MixTable - 4 voies", Rect(100, 100, 1080, 600));
-    window.resizable_(true);
+    if(window.respondsTo(\resizable_)) {
+        window.resizable_(true);
+    } {
+        if(window.respondsTo(\resizable)) {
+            window.resizable = true;
+        };
+    };
     window.background_(darkBackground);
     ~mixWindow = window;
 


### PR DESCRIPTION
## Summary
- wait for the server to register SynthDefs before instantiating mix channel nodes
- guard the window resize call so the UI no longer errors on backends without `resizable_`

## Testing
- not run (GUI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68da758ff02c8333bcd61ce893345461