### PR TITLE
Avoid applying drawFunc to unsupported views

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -4,11 +4,13 @@
     var accentColor = Color.new255(90, 180, 255);
     var textColor = Color.white;
     var applyBorder = { |view, color, width = 1|
-        view.drawFunc = { |v|
-            Pen.color_(color);
-            Pen.width = width;
-            Pen.addRect(v.bounds.insetBy(width * 0.5, width * 0.5));
-            Pen.stroke;
+        if(view.respondsTo(\drawFunc_)) {
+            view.drawFunc = { |v|
+                Pen.color_(color);
+                Pen.width = width;
+                Pen.addRect(v.bounds.insetBy(width * 0.5, width * 0.5));
+                Pen.stroke;
+            };
         };
         view;
     };


### PR DESCRIPTION
## Summary
- guard the border helper so it only assigns a draw function when the view understands `drawFunc_`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da76982e40833386e6479fb2d48350