### PR TITLE
Simplify mixer UI layout

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -1,20 +1,5 @@
 ~createUI = {
     var window, channelViews;
-    var darkBackground = Color.new255(25, 25, 25);
-    var accentColor = Color.new255(90, 180, 255);
-    var textColor = Color.white;
-    var applyBorder = { |view, color, width = 1|
-        if(view.respondsTo(\drawFunc_)) {
-            view.drawFunc = { |v|
-                Pen.color_(color);
-                Pen.width = width;
-                Pen.addRect(v.bounds.insetBy(width * 0.5, width * 0.5));
-                Pen.stroke;
-            };
-        };
-        view;
-    };
-
     var eqSpecs = [
         (band: \high, name: "High", freqRange: [5000, 16000], gainRange: [-60, 20]),
         (band: \mid2, name: "Mid 2", freqRange: [1200, 5000], gainRange: [-60, 20]),
@@ -23,7 +8,7 @@
     ];
 
     if(~mixWindow.notNil) { ~mixWindow.close };
-    window = Window("MixTable - 4 voies", Rect(100, 100, 1080, 600));
+    window = Window("MixTable - 4 voies", Rect(100, 100, 960, 560));
     if(window.respondsTo(\resizable_)) {
         window.resizable_(true);
     } {
@@ -31,70 +16,51 @@
             window.resizable = true;
         };
     };
-    window.background_(darkBackground);
     ~mixWindow = window;
 
     channelViews = ~mixInputs.collect { |cfg, index|
-        var channelContainer, title, gainSlider, gainValueLabel, eqScroll, eqArea, eqControls;
+        var channelContainer, title, gainSlider, gainValueLabel, eqArea, eqControls;
 
         channelContainer = CompositeView(window)
-            .background_(Color.gray(0.12))
             .minWidth_(220);
-        applyBorder.value(channelContainer, Color.gray(0.35), 1);
 
         title = StaticText(channelContainer)
             .string_("Tranche " ++ cfg[\label])
             .align_(\center)
-            .stringColor_(textColor)
             .minHeight_(22);
 
         gainSlider = Slider(channelContainer)
             .orientation_(\vertical)
-            .background_(Color.gray(0.2))
             .minHeight_(160);
 
         gainValueLabel = StaticText(channelContainer)
             .string_("0.0 dB")
             .align_(\center)
-            .stringColor_(accentColor)
             .minHeight_(24);
 
-        eqScroll = ScrollView(channelContainer)
-            .hasHorizontalScroller_(false)
-            .hasVerticalScroller_(true)
-            .minHeight_(220);
-        eqScroll.background_(Color.gray(0.16));
-        applyBorder.value(eqScroll, Color.gray(0.25), 1);
-
-        eqArea = CompositeView(eqScroll)
-            .background_(Color.gray(0.16));
+        eqArea = CompositeView(channelContainer)
+            .minHeight_(440);
 
         eqControls = eqSpecs.collect { |spec|
             var eqContainer, eqName, eqSlider, eqValueLabel;
 
-            eqContainer = CompositeView(eqArea)
-                .background_(Color.gray(0.18));
-            applyBorder.value(eqContainer, Color.gray(0.3), 1);
+            eqContainer = CompositeView(eqArea);
             eqName = StaticText(eqContainer)
                 .string_(spec[\name])
                 .align_(\center)
-                .stringColor_(textColor)
                 .minHeight_(20);
             eqSlider = Slider2D(eqContainer)
-                .background_(Color.gray(0.1))
-                .knobColor_(accentColor)
                 .minHeight_(110);
             eqValueLabel = StaticText(eqContainer)
                 .string_("")
                 .align_(\center)
-                .stringColor_(accentColor)
                 .minHeight_(36);
 
             eqContainer.layout_(VLayout(6,
                 [eqName, 0],
                 [eqSlider, 1],
                 [eqValueLabel, 0]
-            ).margins_(8));
+            ).margins_(4));
 
             eqSlider.action = { |view|
                 var freq = view.x.linexp(0, 1, spec[\freqRange][0], spec[\freqRange][1]);
@@ -107,16 +73,16 @@
             (container: eqContainer, slider: eqSlider, valueLabel: eqValueLabel, spec: spec);
         };
 
-        eqArea.layout_(VLayout(10, *(eqControls.collect { |control|
+        eqArea.layout_(VLayout(6, *(eqControls.collect { |control|
             [control[\container], 1]
-        })).margins_(10));
+        })).margins_(4));
 
-        channelContainer.layout_(VLayout(10,
+        channelContainer.layout_(VLayout(8,
             [title, 0],
             [gainSlider, 1],
             [gainValueLabel, 0],
-            [eqScroll, 3]
-        ).margins_(10));
+            [eqArea, 3]
+        ).margins_(6));
 
         {
             var state = ~getChannelState.value(index);
@@ -144,9 +110,9 @@
         (container: channelContainer);
     };
 
-    window.layout_(HLayout(12, *(channelViews.collect { |control|
+    window.layout_(HLayout(10, *(channelViews.collect { |control|
         [control[\container], 1]
-    })).margins_(12));
+    })).margins_(10));
 
     window.onClose = { ~mixWindow = nil; window.close };
     window.front;


### PR DESCRIPTION
## Summary
- remove decorative styling and borders from the mixer UI
- keep four EQ Slider2D controls per channel in a simple vertical layout
- adjust spacing and sizing for an undecorated presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da77a5ae1c8333b4f50d2d6533873c