### PR TITLE
Add resonance Q control to equalizer

### DIFF
--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -21,35 +21,35 @@ SynthDef(\outputLimiter, { |input = 0, out = 0|
 SynthDef(\mixChannel, {
     |inA = 0, inB = 1, isMono = 0, outBus = 0,
     gainAmp = 1,
-    lowFreq = 120, lowGain = 0,
-    mid1Freq = 500, mid1Gain = 0,
-    mid2Freq = 2000, mid2Gain = 0,
-    highFreq = 8000, highGain = 0|
+    lowFreq = 120, lowRQ = 1, lowGain = 0,
+    mid1Freq = 500, mid1RQ = 1, mid1Gain = 0,
+    mid2Freq = 2000, mid2RQ = 1, mid2Gain = 0,
+    highFreq = 8000, highRQ = 1, highGain = 0|
     var stereo, mono, sig;
     stereo = SoundIn.ar([inA, inB]);
     mono = SoundIn.ar(inA) ! 2;
     sig = (stereo * (1 - isMono)) + (mono * isMono);
-    sig = BLowShelf.ar(sig, lowFreq, 1, lowGain);
-    sig = BPeakEQ.ar(sig, mid1Freq, 1, mid1Gain);
-    sig = BPeakEQ.ar(sig, mid2Freq, 1, mid2Gain);
-    sig = BHiShelf.ar(sig, highFreq, 1, highGain);
+    sig = BLowShelf.ar(sig, lowFreq, lowRQ, lowGain);
+    sig = BPeakEQ.ar(sig, mid1Freq, mid1RQ, mid1Gain);
+    sig = BPeakEQ.ar(sig, mid2Freq, mid2RQ, mid2Gain);
+    sig = BHiShelf.ar(sig, highFreq, highRQ, highGain);
     sig = sig * gainAmp;
     Out.ar(outBus, sig);
 }).add;
 
 // Paramètres d'égalisation par défaut
 ~eqDefaults = (
-    low:  (freq: 120,  gain: 0),
-    mid1: (freq: 500,  gain: 0),
-    mid2: (freq: 2000, gain: 0),
-    high: (freq: 8000, gain: 0)
+    low:  (freq: 120,  gain: 0, q: 1),
+    mid1: (freq: 500,  gain: 0, q: 1),
+    mid2: (freq: 2000, gain: 0, q: 1),
+    high: (freq: 8000, gain: 0, q: 1)
 );
 
 ~eqParamMap = (
-    low:  (freqKey: \lowFreq,  gainKey: \lowGain),
-    mid1: (freqKey: \mid1Freq, gainKey: \mid1Gain),
-    mid2: (freqKey: \mid2Freq, gainKey: \mid2Gain),
-    high: (freqKey: \highFreq, gainKey: \highGain)
+    low:  (freqKey: \lowFreq,  gainKey: \lowGain,  qKey: \lowRQ),
+    mid1: (freqKey: \mid1Freq, gainKey: \mid1Gain, qKey: \mid1RQ),
+    mid2: (freqKey: \mid2Freq, gainKey: \mid2Gain, qKey: \mid2RQ),
+    high: (freqKey: \highFreq, gainKey: \highGain, qKey: \highRQ)
 );
 
 ~setupAudio = {
@@ -93,12 +93,16 @@ SynthDef(\mixChannel, {
             \outBus, ~mixBus,
             \gainAmp, state[\gainDB].dbamp,
             \lowFreq, state[\eq][\low][\freq],
+            \lowRQ, (state[\eq][\low][\q] ?? { 1 }).reciprocal,
             \lowGain, state[\eq][\low][\gain],
             \mid1Freq, state[\eq][\mid1][\freq],
+            \mid1RQ, (state[\eq][\mid1][\q] ?? { 1 }).reciprocal,
             \mid1Gain, state[\eq][\mid1][\gain],
             \mid2Freq, state[\eq][\mid2][\freq],
+            \mid2RQ, (state[\eq][\mid2][\q] ?? { 1 }).reciprocal,
             \mid2Gain, state[\eq][\mid2][\gain],
             \highFreq, state[\eq][\high][\freq],
+            \highRQ, (state[\eq][\high][\q] ?? { 1 }).reciprocal,
             \highGain, state[\eq][\high][\gain]
         ], target: ~inputGroup);
     };
@@ -116,14 +120,19 @@ SynthDef(\mixChannel, {
         };
     };
 
-    ~setChannelEq = { |index, band, freq, gain|
+    ~setChannelEq = { |index, band, freq, gain, q|
         if((index >= 0) and: { index < ~channelSynths.size }) {
             var params = ~eqParamMap[band];
             var synth = ~channelSynths[index];
             if(params.notNil) {
-                synth.tryPerform(\set, params[\freqKey], freq, params[\gainKey], gain);
+                var rq = q.reciprocal;
+                synth.tryPerform(\set,
+                    params[\freqKey], freq,
+                    params[\gainKey], gain,
+                    params[\qKey], rq
+                );
             };
-            ~channelStates[index][\eq][band] = (freq: freq, gain: gain);
+            ~channelStates[index][\eq][band] = (freq: freq, gain: gain, q: q);
         };
     };
 

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -1,10 +1,10 @@
 ~createUI = {
     var window, channelViews;
     var eqSpecs = [
-        (band: \high, name: "High", freqRange: [5000, 16000], gainRange: [-60, 20]),
-        (band: \mid2, name: "Mid 2", freqRange: [1200, 5000], gainRange: [-60, 20]),
-        (band: \mid1, name: "Mid 1", freqRange: [250, 1200], gainRange: [-60, 20]),
-        (band: \low,  name: "Low",  freqRange: [40, 250],   gainRange: [-60, 20])
+        (band: \high, name: "High", freqRange: [5000, 16000], gainRange: [-60, 20], qRange: [0.2, 5]),
+        (band: \mid2, name: "Mid 2", freqRange: [1200, 5000], gainRange: [-60, 20], qRange: [0.2, 10]),
+        (band: \mid1, name: "Mid 1", freqRange: [250, 1200], gainRange: [-60, 20], qRange: [0.2, 10]),
+        (band: \low,  name: "Low",  freqRange: [40, 250],   gainRange: [-60, 20], qRange: [0.2, 5])
     ];
 
     if(~mixWindow.notNil) { ~mixWindow.close };
@@ -42,35 +42,75 @@
             .minHeight_(440);
 
         eqControls = eqSpecs.collect { |spec|
-            var eqContainer, eqName, eqSlider, eqValueLabel;
+            var eqContainer, eqName, sliderRow, eqSlider, eqValueLabel,
+                qContainer, qSlider, qTitle, qValueLabel, qRange, updateDisplay;
 
             eqContainer = CompositeView(eqArea);
             eqName = StaticText(eqContainer)
                 .string_(spec[\name])
                 .align_(\center)
                 .minHeight_(20);
-            eqSlider = Slider2D(eqContainer)
+            sliderRow = CompositeView(eqContainer);
+            eqSlider = Slider2D(sliderRow)
                 .minHeight_(110);
+            qContainer = CompositeView(sliderRow);
+            qTitle = StaticText(qContainer)
+                .string_("Q")
+                .align_(\center)
+                .minHeight_(20);
+            qSlider = Slider(qContainer)
+                .orientation_(\vertical)
+                .minHeight_(110);
+            qValueLabel = StaticText(qContainer)
+                .string_("Q: 1.00")
+                .align_(\center)
+                .minHeight_(24);
             eqValueLabel = StaticText(eqContainer)
                 .string_("")
                 .align_(\center)
                 .minHeight_(36);
 
+            qRange = spec[\qRange] ?? { [0.2, 10] };
+            updateDisplay = { |freq, gain, q|
+                var display = freq.round(1).asString ++ " Hz\n" ++ gain.round(0.1).asString ++ " dB";
+                eqValueLabel.string_(display);
+                qValueLabel.string_("Q: " ++ q.round(0.01).asString);
+            };
+
+            qContainer.layout_(VLayout(4,
+                [qTitle, 0],
+                [qSlider, 1],
+                [qValueLabel, 0]
+            ));
+
+            sliderRow.layout_(HLayout(6,
+                [eqSlider, 1],
+                [qContainer, 0]
+            ));
+
             eqContainer.layout_(VLayout(6,
                 [eqName, 0],
-                [eqSlider, 1],
+                [sliderRow, 1],
                 [eqValueLabel, 0]
             ).margins_(4));
 
             eqSlider.action = { |view|
                 var freq = view.x.linexp(0, 1, spec[\freqRange][0], spec[\freqRange][1]);
                 var gain = view.y.linlin(0, 1, spec[\gainRange][0], spec[\gainRange][1]);
-                var display = freq.round(1).asString ++ " Hz\n" ++ gain.round(0.1).asString ++ " dB";
-                eqValueLabel.string_(display);
-                ~setChannelEq.value(index, spec[\band], freq, gain);
+                var q = qSlider.value.linexp(0, 1, qRange[0], qRange[1]);
+                updateDisplay.(freq, gain, q);
+                ~setChannelEq.value(index, spec[\band], freq, gain, q);
             };
 
-            (container: eqContainer, slider: eqSlider, valueLabel: eqValueLabel, spec: spec);
+            qSlider.action = { |slider|
+                var freq = eqSlider.x.linexp(0, 1, spec[\freqRange][0], spec[\freqRange][1]);
+                var gain = eqSlider.y.linlin(0, 1, spec[\gainRange][0], spec[\gainRange][1]);
+                var q = slider.value.linexp(0, 1, qRange[0], qRange[1]);
+                updateDisplay.(freq, gain, q);
+                ~setChannelEq.value(index, spec[\band], freq, gain, q);
+            };
+
+            (container: eqContainer, slider: eqSlider, qSlider: qSlider, valueLabel: eqValueLabel, qRange: qRange, spec: spec, updateDisplay: updateDisplay);
         };
 
         eqArea.layout_(VLayout(6, *(eqControls.collect { |control|
@@ -102,8 +142,11 @@
                 var eqState = state[\eq][spec[\band]] ?? { ~eqDefaults[spec[\band]].copy };
                 var x = eqState[\freq].linexp(spec[\freqRange][0], spec[\freqRange][1], 0, 1).clip(0, 1);
                 var y = eqState[\gain].linlin(spec[\gainRange][0], spec[\gainRange][1], 0, 1).clip(0, 1);
+                var qValue = (eqState[\q] ?? { 1 }).clip(control[\qRange][0], control[\qRange][1]);
+                var qSliderValue = qValue.explin(control[\qRange][0], control[\qRange][1], 0, 1).clip(0, 1);
                 control[\slider].setXY(x, y);
-                control[\valueLabel].string_(eqState[\freq].round(1).asString ++ " Hz\n" ++ eqState[\gain].round(0.1).asString ++ " dB");
+                control[\qSlider].value_(qSliderValue);
+                control[\updateDisplay].(eqState[\freq], eqState[\gain], qValue);
             };
         }.value;
 


### PR DESCRIPTION
## Summary
- add a dedicated Q slider beside each EQ band control in the UI
- store and display the resonance parameter while keeping frequency and gain interactions intact
- extend the mix channel synth to accept per-band resonance and persist the new state values

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da824a41cc8333a1db59d4ec0c2cfa