### PR TITLE
Remove UI labels and align Q slider heights

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -19,86 +19,44 @@
     ~mixWindow = window;
 
     channelViews = ~mixInputs.collect { |cfg, index|
-        var channelContainer, title, gainSlider, gainValueLabel, eqArea, eqControls;
+        var channelContainer, gainSlider, eqArea, eqControls;
 
         channelContainer = CompositeView(window)
             .minWidth_(220);
-
-        title = StaticText(channelContainer)
-            .string_("Tranche " ++ cfg[\label])
-            .align_(\center)
-            .minHeight_(22);
 
         gainSlider = Slider(channelContainer)
             .orientation_(\vertical)
             .minHeight_(160);
 
-        gainValueLabel = StaticText(channelContainer)
-            .string_("0.0 dB")
-            .align_(\center)
-            .minHeight_(24);
-
         eqArea = CompositeView(channelContainer)
             .minHeight_(440);
 
         eqControls = eqSpecs.collect { |spec|
-            var eqContainer, eqName, sliderRow, eqSlider, eqValueLabel,
-                qContainer, qSlider, qTitle, qValueLabel, qRange, updateDisplay;
+            var eqContainer, sliderRow, eqSlider, qSlider, qRange;
 
             eqContainer = CompositeView(eqArea);
-            eqName = StaticText(eqContainer)
-                .string_(spec[\name])
-                .align_(\center)
-                .minHeight_(20);
             sliderRow = CompositeView(eqContainer);
             eqSlider = Slider2D(sliderRow)
                 .minHeight_(110);
-            qContainer = CompositeView(sliderRow);
-            qTitle = StaticText(qContainer)
-                .string_("Q")
-                .align_(\center)
-                .minHeight_(20);
-            qSlider = Slider(qContainer)
+            qSlider = Slider(sliderRow)
                 .orientation_(\vertical)
                 .minHeight_(110);
-            qValueLabel = StaticText(qContainer)
-                .string_("Q: 1.00")
-                .align_(\center)
-                .minHeight_(24);
-            eqValueLabel = StaticText(eqContainer)
-                .string_("")
-                .align_(\center)
-                .minHeight_(36);
 
             qRange = spec[\qRange] ?? { [0.2, 10] };
-            updateDisplay = { |freq, gain, q|
-                var display = freq.round(1).asString ++ " Hz\n" ++ gain.round(0.1).asString ++ " dB";
-                eqValueLabel.string_(display);
-                qValueLabel.string_("Q: " ++ q.round(0.01).asString);
-            };
-
-            qContainer.layout_(VLayout(4,
-                [qTitle, 0],
-                [qSlider, 1],
-                [qValueLabel, 0]
-            ));
 
             sliderRow.layout_(HLayout(6,
                 [eqSlider, 1],
-                [qContainer, 0]
+                [qSlider, 0]
             ));
 
             eqContainer.layout_(VLayout(6,
-                [eqName, 0],
-                [sliderRow, 1],
-                [eqValueLabel, 0]
+                [sliderRow, 1]
             ).margins_(4));
 
             eqSlider.action = { |view|
                 var freq = view.x.linexp(0, 1, spec[\freqRange][0], spec[\freqRange][1]);
                 var gain = view.y.linlin(0, 1, spec[\gainRange][0], spec[\gainRange][1]);
                 var q = qSlider.value.linexp(0, 1, qRange[0], qRange[1]);
-                updateDisplay.(freq, gain, q);
                 ~setChannelEq.value(index, spec[\band], freq, gain, q);
             };
 
@@ -106,11 +64,10 @@
                 var freq = eqSlider.x.linexp(0, 1, spec[\freqRange][0], spec[\freqRange][1]);
                 var gain = eqSlider.y.linlin(0, 1, spec[\gainRange][0], spec[\gainRange][1]);
                 var q = slider.value.linexp(0, 1, qRange[0], qRange[1]);
-                updateDisplay.(freq, gain, q);
                 ~setChannelEq.value(index, spec[\band], freq, gain, q);
             };
 
-            (container: eqContainer, slider: eqSlider, qSlider: qSlider, valueLabel: eqValueLabel, qRange: qRange, spec: spec, updateDisplay: updateDisplay);
+            (container: eqContainer, slider: eqSlider, qSlider: qSlider, qRange: qRange, spec: spec);
         };
 
         eqArea.layout_(VLayout(6, *(eqControls.collect { |control|
@@ -118,9 +75,7 @@
         })).margins_(4));
 
         channelContainer.layout_(VLayout(8,
-            [title, 0],
             [gainSlider, 1],
-            [gainValueLabel, 0],
             [eqArea, 3]
         ).margins_(6));
 
@@ -129,11 +84,9 @@
             var gainDB = state[\gainDB] ?? { 0 };
             var sliderValue = gainDB.linlin(-60, 20, 0, 1).clip(0, 1);
             gainSlider.value_(sliderValue);
-            gainValueLabel.string_(gainDB.round(0.1).asString ++ " dB");
 
             gainSlider.action = { |sl|
                 var db = sl.value.linlin(0, 1, -60, 20);
-                gainValueLabel.string_(db.round(0.1).asString ++ " dB");
                 ~setChannelGain.value(index, db);
             };
 
@@ -146,7 +99,6 @@
                 var qSliderValue = qValue.explin(control[\qRange][0], control[\qRange][1], 0, 1).clip(0, 1);
                 control[\slider].setXY(x, y);
                 control[\qSlider].value_(qSliderValue);
-                control[\updateDisplay].(eqState[\freq], eqState[\gain], qValue);
             };
         }.value;
 


### PR DESCRIPTION
## Summary
- remove all label widgets from the channel and EQ interfaces to simplify the UI
- ensure Q sliders share the same layout height as the XY EQ sliders by placing them directly in the slider row

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da85bd644c8333b88476b9194d34ce