### PR TITLE
Add mute buttons under gain faders

### DIFF
--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -18,20 +18,21 @@ SynthDef(\outputLimiter, { |input = 0, out = 0|
 // SynthDef pour chaque tranche d'entrée avec égalisation 4 bandes
 SynthDef(\mixChannel, {
     |inA = 0, inB = 1, isMono = 0, outBus = 0,
-    gainAmp = 1,
+    gainAmp = 1, mute = 0,
     lowFreq = 120, lowRQ = 1, lowGain = 0,
     mid1Freq = 500, mid1RQ = 1, mid1Gain = 0,
     mid2Freq = 2000, mid2RQ = 1, mid2Gain = 0,
     highFreq = 8000, highRQ = 1, highGain = 0|
-    var stereo, mono, sig;
+    var stereo, mono, sig, muteLevel;
     stereo = SoundIn.ar([inA, inB]);
     mono = SoundIn.ar(inA) ! 2;
     sig = (stereo * (1 - isMono)) + (mono * isMono);
-    sig = BLowShelf.ar(sig, lowFreq, lowRQ, lowGain.lag(0.1);
-    sig = BPeakEQ.ar(sig, mid1Freq, mid1RQ, mid1Gain.lag(0.1);
-    sig = BPeakEQ.ar(sig, mid2Freq, mid2RQ, mid2Gain.lag(0.1);
-    sig = BHiShelf.ar(sig, highFreq, highRQ, highGain.lag(0.1);
-    sig = sig * gainAmp;
+    sig = BLowShelf.ar(sig, lowFreq, lowRQ, lowGain.lag(0.1));
+    sig = BPeakEQ.ar(sig, mid1Freq, mid1RQ, mid1Gain.lag(0.1));
+    sig = BPeakEQ.ar(sig, mid2Freq, mid2RQ, mid2Gain.lag(0.1));
+    sig = BHiShelf.ar(sig, highFreq, highRQ, highGain.lag(0.1));
+    muteLevel = Lag.kr(1 - mute, 0.05);
+    sig = sig * gainAmp * muteLevel;
     Out.ar(outBus, sig);
 }).add;
 
@@ -79,7 +80,7 @@ SynthDef(\mixChannel, {
         ~eqDefaults.keysValuesDo { |band, defaults|
             eqState[band] = defaults.copy;
         };
-        (gainDB: 0, eq: eqState);
+        (gainDB: 0, eq: eqState, muted: 0);
     });
 
     ~channelSynths = ~mixInputs.collect { |cfg, index|
@@ -101,7 +102,8 @@ SynthDef(\mixChannel, {
             \mid2Gain, state[\eq][\mid2][\gain],
             \highFreq, state[\eq][\high][\freq],
             \highRQ, (state[\eq][\high][\q] ?? { 1 }).reciprocal,
-            \highGain, state[\eq][\high][\gain]
+            \highGain, state[\eq][\high][\gain],
+            \mute, state[\muted]
         ], target: ~inputGroup);
     };
 
@@ -115,6 +117,15 @@ SynthDef(\mixChannel, {
             var synth = ~channelSynths[index];
             ~channelStates[index][\gainDB] = db;
             synth.tryPerform(\set, \gainAmp, db.dbamp);
+        };
+    };
+
+    ~setChannelMute = { |index, muted|
+        if((index >= 0) and: { index < ~channelSynths.size }) {
+            var synth = ~channelSynths[index];
+            var muteValue = muted.clip(0, 1);
+            ~channelStates[index][\muted] = muteValue;
+            synth.tryPerform(\set, \mute, muteValue);
         };
     };
 
@@ -140,7 +151,7 @@ SynthDef(\mixChannel, {
             ~eqDefaults.keysValuesDo { |band, defaults|
                 eqState[band] = defaults.copy;
             };
-            (gainDB: 0, eq: eqState);
+            (gainDB: 0, eq: eqState, muted: 0);
         };
     };
 

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -19,14 +19,23 @@
     ~mixWindow = window;
 
     channelViews = ~mixInputs.collect { |cfg, index|
-        var channelContainer, gainSlider, eqArea, eqControls;
+        var channelContainer, gainSection, gainSlider, muteButton, eqArea, eqControls;
 
         channelContainer = CompositeView(window)
             .minWidth_(220);
 
-        gainSlider = Slider(channelContainer)
+        gainSection = CompositeView(channelContainer);
+
+        gainSlider = Slider(gainSection)
             .orientation_(\vertical)
             .minHeight_(160);
+
+        muteButton = Button(gainSection)
+            .states_([
+                ["Mute", Color.black, Color(0.85, 0.85, 0.85)],
+                ["Muted", Color.white, Color(0.8, 0.2, 0.2)]
+            ])
+            .maxHeight_(28);
 
         eqArea = CompositeView(channelContainer)
             .minHeight_(440);
@@ -74,8 +83,13 @@
             [control[\container], 1]
         })).margins_(4));
 
-        channelContainer.layout_(VLayout(8,
+        gainSection.layout_(VLayout(6,
             [gainSlider, 1],
+            [muteButton, 0]
+        ).margins_(4));
+
+        channelContainer.layout_(VLayout(8,
+            [gainSection, 1],
             [eqArea, 3]
         ).margins_(6));
 
@@ -83,11 +97,18 @@
             var state = ~getChannelState.value(index);
             var gainDB = state[\gainDB] ?? { 0 };
             var sliderValue = gainDB.linlin(-60, 20, 0, 1).clip(0, 1);
+            var isMuted = state[\muted] ?? { 0 };
             gainSlider.value_(sliderValue);
+            muteButton.value_(isMuted);
 
             gainSlider.action = { |sl|
                 var db = sl.value.linlin(0, 1, -60, 20);
                 ~setChannelGain.value(index, db);
+            };
+
+            muteButton.action = { |btn|
+                var muted = btn.value.clip(0, 1);
+                ~setChannelMute.value(index, muted);
             };
 
             eqControls.do { |control|


### PR DESCRIPTION
## Summary
- add a mute control to each mix channel synth and persist the muted state
- expose a new helper to toggle channel mute state from the UI
- update the mixer UI to show a mute toggle button beneath each gain fader

## Testing
- not run (SuperCollider environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68da877502b48333818c7431671ecd80