### PR TITLE
Add NPVoicer-driven Braids voice on channel 1

### DIFF
--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -5,27 +5,115 @@ SynthDef(\outputLimiter, { |input = 0, out = 0|
     Out.ar(out, limited.tanh);
 }).add;
 
+// ================= Voix Mutable Instruments Braids =================
+~rootNote = ~rootNote ?? { 0 };
+~scale = ~scale ?? { Scale.chromatic };
+~enableBraidsVoicer = ~enableBraidsVoicer ?? { true };
+
+SynthDef(\braidsVoice, {
+    |out = 0, freq = 440, vel = 1, amp = 1, mod = 0, bend = 0, gate = 1|
+    var pitch, env, timbre, color, trig, sig;
+    pitch = freq * bend.midiratio;
+    timbre = mod.linlin(0, 1, 0.05, 0.95);
+    color = amp.clip(0, 1);
+    trig = (vel > 0).if(1, 0);
+    env = EnvGen.kr(Env.asr(0.01, 1, 0.3), gate, doneAction: 2);
+    sig = MiBraids.ar(pitch, timbre: timbre, color: color, model: 0, trig: trig, resamp: 2);
+    sig = sig * (vel.clip(0, 1) * amp.clip(0, 1)) * env;
+    Out.ar(out, sig!2);
+}).add;
+
+~configureBraidsVoicer = {
+    |uid, voicer, bank, out|
+    var midiDefs = List.new;
+
+    voicer.indivParams;
+    voicer.roli.prime(\braidsVoice);
+
+    voicer.makeNote = { |q, chan, note = 60, vel = 64|
+        voicer.roli.put(chan, [
+            \freq, (note + ~rootNote).keyToDegree(~scale, 12).degreeToKey(~scale).midicps,
+            \vel, (vel / 127),
+            \amp, 1,
+            \gate, 1,
+            \out, out
+        ]);
+    };
+
+    voicer.endNote = { |q, chan|
+        var obj = voicer.roli.proxy.objects[chan];
+        if(obj.notNil) { obj.set(\gate, 0) };
+    };
+
+    voicer.setTouch = { |q, chan = 0, touchval = 64|
+        var obj = voicer.roli.proxy.objects[chan];
+        if(obj.notNil) { obj.set(\amp, (touchval / 127)) };
+    };
+
+    voicer.setSlide = { |q, chan = 0, slide = 0|
+        var obj = voicer.roli.proxy.objects[chan];
+        if(obj.notNil) { obj.set(\mod, (slide / 127)) };
+    };
+
+    voicer.setBend = { |q, chan = 0, bendval = 0|
+        var obj = voicer.roli.proxy.objects[chan];
+        if(obj.notNil) {
+            obj.set(\bend, bendval.linlin(0, 16383, -36, 36))
+        };
+    };
+
+    midiDefs.add(MIDIdef.noteOn(\roliOn ++ out, { |vel, noteNum, chan|
+        voicer.makeNote(chan, noteNum, vel);
+    }, srcID: uid).enable);
+
+    midiDefs.add(MIDIdef.noteOff(\roliOff ++ out, { |vel, noteNum, chan|
+        voicer.endNote(chan, noteNum);
+    }, srcID: uid).enable);
+
+    midiDefs.add(MIDIdef.cc(\roliSlide ++ out, { |val, ccnum, chan|
+        voicer.setSlide(chan, val);
+    }, 1, srcID: uid).enable);
+
+    midiDefs.add(MIDIdef.touch(\roliTouch ++ out, { |val, chan, src|
+        voicer.setTouch(chan, val);
+    }, srcID: uid).enable);
+
+    midiDefs.add(MIDIdef.bend(\roliBend ++ out, { |bend, chan|
+        voicer.setBend(chan, bend);
+    }, srcID: uid).enable);
+
+    midiDefs
+};
+
 // ================= Mixage et gestion des bus =================
 
 // Définitions des tranches d'entrée : 1 (mono), 3/4, 5/6, 7/8
-~mixInputs = [
-    (label: "1",     channels: [0, 0], isMono: 1),
-    (label: "3 / 4", channels: [2, 3], isMono: 0),
-    (label: "5 / 6", channels: [4, 5], isMono: 0),
-    (label: "7 / 8", channels: [6, 7], isMono: 0)
+~braidsMidiDefs = ~braidsMidiDefs ?? { List.new };
+
+~defaultMixInputs = [
+    (label: "1",     channels: [0, 0], isMono: 1, useSoundIn: 1),
+    (label: "3 / 4", channels: [2, 3], isMono: 0, useSoundIn: 1),
+    (label: "5 / 6", channels: [4, 5], isMono: 0, useSoundIn: 1),
+    (label: "7 / 8", channels: [6, 7], isMono: 0, useSoundIn: 1)
 ];
+~mixInputs = ~defaultMixInputs.collect(_.copy);
 
 // SynthDef pour chaque tranche d'entrée avec égalisation 4 bandes
 SynthDef(\mixChannel, {
-    |inA = 0, inB = 1, isMono = 0, outBus = 0,
+    |inA = 0, inB = 1, isMono = 0, outBus = 0, useSoundIn = 1,
     gainAmp = 1, mute = 0,
     lowFreq = 120, lowRQ = 1, lowGain = 0,
     mid1Freq = 500, mid1RQ = 1, mid1Gain = 0,
     mid2Freq = 2000, mid2RQ = 1, mid2Gain = 0,
     highFreq = 8000, highRQ = 1, highGain = 0|
     var stereo, mono, sig, muteLevel;
-    stereo = SoundIn.ar([inA, inB]);
-    mono = SoundIn.ar(inA) ! 2;
+    if(useSoundIn > 0.5) {
+        stereo = SoundIn.ar([inA, inB]);
+        mono = SoundIn.ar(inA) ! 2;
+    } {
+        stereo = In.ar(inA, 2);
+        mono = In.ar(inA, 1) ! 2;
+    };
     sig = (stereo * (1 - isMono)) + (mono * isMono);
     sig = BLowShelf.ar(sig, lowFreq, lowRQ, lowGain.lag(0.1));
     sig = BPeakEQ.ar(sig, mid1Freq, mid1RQ, mid1Gain.lag(0.1));
@@ -53,7 +141,7 @@ SynthDef(\mixChannel, {
 
 ~setupAudio = {
     // Nettoyage si nécessaire
-    [~channelSynths, ~limiterSynth].do { |item|
+    [~channelSynths, ~limiterSynth, ~braidsVoicer].do { |item|
         if(item.notNil) {
             if(item.isKindOf(Array)) {
                 item.do(_.tryPerform(\free));
@@ -63,8 +151,14 @@ SynthDef(\mixChannel, {
         };
     };
 
-    [~inputGroup, ~outputGroup].do(_.tryPerform(\free));
-    ~mixBus.tryPerform(\free);
+    ~braidsVoicer = nil;
+
+    ~braidsMidiDefs.do { |def| def.tryPerform(\free) };
+    ~braidsMidiDefs = List.new;
+
+    [~voiceGroup, ~inputGroup, ~outputGroup].do(_.tryPerform(\free));
+    [~mixBus, ~voiceBus].do { |bus| bus.tryPerform(\free) };
+    ~voiceBus = nil;
 
     // S'assurer que toutes les définitions de synthés précédemment envoyées
     // ont bien été traitées par le serveur avant d'instancier de nouveaux nodes.
@@ -72,8 +166,46 @@ SynthDef(\mixChannel, {
 
     ~mixBus = Bus.audio(s, 2);
 
-    ~inputGroup = Group.head(s);
+    ~mixInputs = ~defaultMixInputs.collect(_.copy);
+
+    ~voiceGroup = Group.head(s);
+    ~inputGroup = Group.after(~voiceGroup);
     ~outputGroup = Group.after(~inputGroup);
+
+    if(~enableBraidsVoicer ?? { true }) {
+        if(thisProcess.interpreter.notNil and: { NPVoicer.notNil }) {
+            var iacSource, uid;
+            MIDIClient.init;
+            iacSource = MIDIClient.sources.detect { |src|
+                var name = [src.device, src.name].collect(_.asString).join(" ");
+                name.contains("IAC");
+            };
+            if(iacSource.notNil) {
+                uid = iacSource.uid;
+                ~voiceBus = Bus.audio(s, 2);
+                ~mixInputs[0] = ~mixInputs[0].copy.putAll((
+                    label: "NPV Braids",
+                    channels: [~voiceBus.index, ~voiceBus.index + 1],
+                    isMono: 0,
+                    useSoundIn: 0
+                ));
+                ~braidsVoicer = NPVoicer(15, \braidsVoice, target: ~voiceGroup, out: ~voiceBus.index);
+                if(~braidsVoicer.notNil) {
+                    ~braidsMidiDefs.do { |def| def.tryPerform(\free) };
+                    ~braidsMidiDefs = ~configureBraidsVoicer.value(uid, ~braidsVoicer, nil, ~voiceBus.index);
+                } {
+                    "Impossible de créer le NPVoicer pour la voix Braids.".warn;
+                    ~mixInputs[0] = ~defaultMixInputs[0].copy;
+                    ~voiceBus.tryPerform(\free);
+                    ~voiceBus = nil;
+                };
+            } {
+                "Aucune source MIDI IAC trouvée pour le NPVoicer.".warn;
+            };
+        } {
+            "NPVoicer n'est pas disponible dans cet environnement.".warn;
+        };
+    };
 
     ~channelStates = Array.fill(~mixInputs.size, {
         var eqState = IdentityDictionary.new;
@@ -90,6 +222,7 @@ SynthDef(\mixChannel, {
             \inB, cfg[\channels][1],
             \isMono, cfg[\isMono],
             \outBus, ~mixBus,
+            \useSoundIn, cfg[\useSoundIn] ?? { 1 },
             \gainAmp, state[\gainDB].dbamp,
             \lowFreq, state[\eq][\low][\freq],
             \lowRQ, (state[\eq][\low][\q] ?? { 1 }).reciprocal,
@@ -156,12 +289,15 @@ SynthDef(\mixChannel, {
     };
 
     CmdPeriod.doOnce({
-        [~channelSynths, ~limiterSynth].do { |item|
+        [~channelSynths, ~limiterSynth, ~braidsVoicer].do { |item|
             if(item.notNil) {
                 if(item.isKindOf(Array)) { item.do(_.tryPerform(\free)) } { item.tryPerform(\free) };
             };
         };
-        [~mixBus].do { |bus| bus.tryPerform(\free) };
-        [~inputGroup, ~outputGroup].do(_.tryPerform(\free));
+        ~braidsMidiDefs.do { |def| def.tryPerform(\free) };
+        [~mixBus, ~voiceBus].do { |bus| bus.tryPerform(\free) };
+        [~voiceGroup, ~inputGroup, ~outputGroup].do(_.tryPerform(\free));
+        ~voiceBus = nil;
+        ~braidsVoicer = nil;
     });
 };


### PR DESCRIPTION
## Summary
- add a Mutable Instruments Braids synth voice and configuration helper for NPVoicer
- route mix channel 1 through an internal bus when the Braids voicer is available
- extend audio setup/cleanup to manage the new NPVoicer, MIDI bindings, and routing groups

## Testing
- not run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd282f94e48333824603d9d8ac0d8f