### PR TITLE
Route voicer synth through mixer channel 1

### DIFF
--- a/config/transbus_sc1.scd
+++ b/config/transbus_sc1.scd
@@ -1,0 +1,74 @@
+~transBusConfig = (
+    device: "TransBus",
+    port: "SC1"
+);
+
+~rootNote = ~rootNote ? 0;
+~scale = ~scale ? Scale.chromatic;
+~tempo = ~tempo ? 1;
+
+~braidsVoicer = nil;
+
+~teardownBraidsVoicer = {
+    ~braidsVoicer !? { |current|
+        current.midiDefs !? { |defs|
+            defs.values.do { |def| def.tryPerform(\free); };
+        };
+        current.roli.tryPerform(\releaseAll);
+        current.roli.tryPerform(\stop);
+        current.proxy.tryPerform(\stop);
+        current.proxy.tryPerform(\clear);
+        current.proxy.tryPerform(\free);
+        current.bus.tryPerform(\free);
+    };
+    ~braidsVoicer = nil;
+};
+
+~findMidiSource = { |device, port|
+    MIDIClient.sources.detect { |src|
+        (src.device == device) and: { src.name == port }
+    };
+};
+
+~setupBraidsVoicer = { |voiceGroup, mixInputs, channelIndex = 0, defaultConfig|
+    var midiSource, midiUID, outputBus, proxy, roli, voicer, updatedConfig;
+
+    ~teardownBraidsVoicer.value;
+
+    MIDIClient.init;
+    MIDIIn.connectAll;
+
+    midiSource = ~findMidiSource.value(~transBusConfig[\device], ~transBusConfig[\port]);
+    if(midiSource.isNil) {
+        ("Source MIDI % % introuvable").format(~transBusConfig[\device], ~transBusConfig[\port]).warn;
+    };
+    midiUID = midiSource.tryPerform(\uid);
+
+    outputBus = Bus.audio(s, 2);
+    proxy = NodeProxy.audio(s, 2);
+    proxy.play(outputBus, 2, voiceGroup);
+    roli = NPVoicerL(proxy, [\freq, \amp, \mod, \bend, \out]);
+
+    voicer = (
+        proxy: proxy,
+        roli: roli,
+        bus: outputBus,
+        indivParams: [\freq, \amp, \mod, \bend, \out],
+        midiSource: midiSource,
+        uid: midiUID
+    );
+
+    ~makeVoice.value(midiUID, voicer, 0, outputBus.index);
+
+    updatedConfig = (defaultConfig ? ()).copy;
+    updatedConfig.putAll((
+        label: "Synth 1",
+        channels: [outputBus.index, outputBus.index + 1],
+        isMono: 0,
+        useSoundIn: 0
+    ));
+
+    mixInputs[channelIndex] = updatedConfig;
+
+    ~braidsVoicer = voicer;
+};

--- a/main.scd
+++ b/main.scd
@@ -11,6 +11,7 @@ s.options.numInputBusChannels = 8;
 // Initialisation
 // ======================
 ~bootMixTable = {
+    ("config/transbus_sc1.scd").loadRelative;
     ("modules/voicer.scd").loadRelative;
     ("modules/mixer.scd").loadRelative;
     ("modules/ui.scd").loadRelative;

--- a/modules/mixer.scd
+++ b/modules/mixer.scd
@@ -7,10 +7,10 @@ SynthDef(\outputLimiter, { |input = 0, out = 0|
 
 // ================= Mixage et gestion des bus =================
 
-// Définitions des tranches d'entrée : 1 (mono), 3/4, 5/6, 7/8
+// Définitions des tranches d'entrée : Synth 1, 3/4, 5/6, 7/8
 
 ~defaultMixInputs = [
-    (label: "1",     channels: [0, 0], isMono: 1, useSoundIn: 1),
+    (label: "Synth 1", channels: [0, 1], isMono: 0, useSoundIn: 0),
     (label: "3 / 4", channels: [2, 3], isMono: 0, useSoundIn: 1),
     (label: "5 / 6", channels: [4, 5], isMono: 0, useSoundIn: 1),
     (label: "7 / 8", channels: [6, 7], isMono: 0, useSoundIn: 1)

--- a/modules/voicer.scd
+++ b/modules/voicer.scd
@@ -1,62 +1,65 @@
 ~makeVoice  =
-	{|uid, voicer, bank, out|
+        {|uid, voicer, bank, out|
+        var midiDefs = IdentityDictionary.new;
 
-	voicer.indivParams;
+        voicer.indivParams;
 
-	voicer.roli.prime(\synth1);
+        voicer.roli.prime(\synth1);
 
-	voicer.makeNote = { |q, chan, note = 60, vel = 64|
-		voicer.roli.put(chan, [
-			\freq, (note + ~rootNote).keyToDegree(~scale,12).degreeToKey(~scale).midicps,
-			\vel, (vel/127),
-			\out, out
-			]);
-	};
-	voicer.endNote = { |q, chan|
-		var obj = voicer.roli.proxy.objects[chan];
-		if (obj.notNil) { obj.set(\gate, 0) };
-	};
+        voicer.makeNote = { |q, chan, note = 60, vel = 64|
+                voicer.roli.put(chan, [
+                        \freq, (note + ~rootNote).keyToDegree(~scale,12).degreeToKey(~scale).midicps,
+                        \amp, (vel/127),
+                        \out, out
+                        ]);
+        };
+        voicer.endNote = { |q, chan|
+                var obj = voicer.roli.proxy.objects[chan];
+                if (obj.notNil) { obj.set(\gate, 0) };
+        };
 
-	voicer.setTouch = { |q, chan=0, touchval = 64|
-		var obj = voicer.roli.proxy.objects[chan];
-		if (obj.notNil) { obj.set(\amp, (touchval/127)) };
-	};
-	voicer.setSlide = { |q, chan=0, slide = 0|
-		var obj = voicer.roli.proxy.objects[chan];
-		// "slide: % % %\n".postf(chan, slide);
-		if (obj.notNil) { obj.set(\mod, (slide/127)) };
-	};
-	voicer.setBend = { |q, chan=0, bendval = 0|
-		var obj = voicer.roli.proxy.objects[chan];
-		if (obj.notNil) { obj.set(\bend,
-			bendval.linlin(0, 16383, -36, 36)) };o
-	};
+        voicer.setTouch = { |q, chan=0, touchval = 64|
+                var obj = voicer.roli.proxy.objects[chan];
+                if (obj.notNil) { obj.set(\amp, (touchval/127)) };
+        };
+        voicer.setSlide = { |q, chan=0, slide = 0|
+                var obj = voicer.roli.proxy.objects[chan];
+                // "slide: % % %\n".postf(chan, slide);
+                if (obj.notNil) { obj.set(\mod, (slide/127)) };
+        };
+        voicer.setBend = { |q, chan=0, bendval = 0|
+                var obj = voicer.roli.proxy.objects[chan];
+                if (obj.notNil) { obj.set(\bend,
+                        bendval.linlin(0, 16383, -36, 36)) };
+        };
 
-	MIDIdef.noteOn(\roliOn ++ out, { |vel, noteNum, chan|
-		// "noteOn: % % %\n".postf(noteNum, vel, chan);
-		voicer.makeNote(chan, noteNum, vel);
-	},srcID:uid).enable;
+        midiDefs[\noteOn] = MIDIdef.noteOn(\roliOn ++ out, { |vel, noteNum, chan|
+                // "noteOn: % % %\n".postf(noteNum, vel, chan);
+                voicer.makeNote(chan, noteNum, vel);
+        },srcID:uid).enable;
 
-	MIDIdef.noteOff(\roliOff ++ out, { |vel, noteNum, chan|
-		// "noteOff: % % %\n".postf(noteNum, vel, chan);
-		voicer.endNote(chan, noteNum);
-	},srcID:uid).enable;
+        midiDefs[\noteOff] = MIDIdef.noteOff(\roliOff ++ out, { |vel, noteNum, chan|
+                // "noteOff: % % %\n".postf(noteNum, vel, chan);
+                voicer.endNote(chan, noteNum);
+        },srcID:uid).enable;
 
-	MIDIdef.cc(\roliSlide ++ out, { |val, ccnum, chan|
-		// ("slide " + ccnum  + val + chan).postln;
-		voicer.setSlide(chan, val);
-	},1,srcID:uid).enable;
+        midiDefs[\slide] = MIDIdef.cc(\roliSlide ++ out, { |val, ccnum, chan|
+                // ("slide " + ccnum  + val + chan).postln;
+                voicer.setSlide(chan, val);
+        },1,srcID:uid).enable;
 
-	MIDIdef.touch(\roliTouch ++ out, { |val, chan, src|
-		("touch " + val + chan).postln;
-		voicer.setTouch(chan, val);
-	},srcID:uid).enable;
-	MIDIdef.bend(\roliBend ++ out, { |bend, chan|
-		// "bend: % %\n".postf(bend, chan);
-		voicer.setBend(chan, bend);
-	},srcID:uid).enable;
-	// MIDIdef.program(\roliProgram ++ out, { |prog, chan|
-	// 	"program: % %\n".postf(prog, chan);
-	// 	voicer.roli.prime(~presets[bank][prog])
-	// },srcID:uid).enable;
-	};
+        midiDefs[\touch] = MIDIdef.touch(\roliTouch ++ out, { |val, chan, src|
+                voicer.setTouch(chan, val);
+        },srcID:uid).enable;
+        midiDefs[\bend] = MIDIdef.bend(\roliBend ++ out, { |bend, chan|
+                // "bend: % %\n".postf(bend, chan);
+                voicer.setBend(chan, bend);
+        },srcID:uid).enable;
+        // MIDIdef.program(\roliProgram ++ out, { |prog, chan|
+        //      "program: % %\n".postf(prog, chan);
+        //      voicer.roli.prime(~presets[bank][prog])
+        // },srcID:uid).enable;
+        voicer.midiDefs = midiDefs;
+        voicer.uid = uid;
+        voicer.out = out;
+        };


### PR DESCRIPTION
## Summary
- load the TransBus SC1 configuration during boot
- route the voicer-controlled synth into channel 1 instead of the audio interface input
- track voicer MIDI definitions so they can be cleaned up with the new configuration

## Testing
- not run (SuperCollider environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd3e3e03408333ac0b32dd82a1358d