### PR TITLE
Load synth definitions during boot

### DIFF
--- a/main.scd
+++ b/main.scd
@@ -12,6 +12,7 @@ s.options.numInputBusChannels = 8;
 // ======================
 ~bootMixTable = {
     ("config/transbus_sc1.scd").loadRelative;
+    ("modules/synth.scd").loadRelative;
     ("modules/voicer.scd").loadRelative;
     ("modules/mixer.scd").loadRelative;
     ("modules/ui.scd").loadRelative;


### PR DESCRIPTION
## Summary
- ensure the synth definitions are loaded when booting MixTable so the voicer can use them

## Testing
- not run (SuperCollider environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd4340e9b48333b1f18b17f054f78e