### PR TITLE
Ensure new voices initialise playback parameters

### DIFF
--- a/modules/voicer.scd
+++ b/modules/voicer.scd
@@ -7,9 +7,14 @@
         voicer.roli.prime(\synth1);
 
         voicer.makeNote = { |q, chan, note = 60, vel = 64|
+                var velocity = vel.max(1) / 127; // avoid a zero velocity on note-on
                 voicer.roli.put(chan, [
                         \freq, (note + ~rootNote).keyToDegree(~scale,12).degreeToKey(~scale).midicps,
-                        \amp, (vel/127),
+                        \amp, velocity,
+                        \gate, 1,
+                        \mod, 0,
+                        \bend, 0,
+                        \pan, 0,
                         \out, out
                         ]);
         };


### PR DESCRIPTION
## Summary
- initialise default modulation, bend and pan values when creating a new voice
- send an explicit gate-on message and guard against zero velocity so envelopes open reliably

## Testing
- not run (SuperCollider environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd449f3e5c833396888775b786f891