### PR TITLE
Fix mix bus routing

### DIFF
--- a/config/transbus_sc1.scd
+++ b/config/transbus_sc1.scd
@@ -46,7 +46,7 @@
 
     outputBus = Bus.audio(s, 2);
     proxy = NodeProxy.audio(s, 2);
-    proxy.play(outputBus, 2, voiceGroup);
+    proxy.play(outputBus.index, 2, voiceGroup);
     roli = NPVoicerL(proxy, [\freq, \amp, \mod, \bend, \out]);
 
     voicer = (

--- a/modules/mixer.scd
+++ b/modules/mixer.scd
@@ -105,7 +105,7 @@ SynthDef(\mixChannel, {
             \inA, cfg[\channels][0],
             \inB, cfg[\channels][1],
             \isMono, cfg[\isMono],
-            \outBus, ~mixBus,
+            \outBus, ~mixBus.index,
             \useSoundIn, cfg[\useSoundIn] ?? { 1 },
             \gainAmp, state[\gainDB].dbamp,
             \lowFreq, state[\eq][\low][\freq],
@@ -125,7 +125,7 @@ SynthDef(\mixChannel, {
     };
 
     ~limiterSynth = Synth(\outputLimiter, [
-        \input, ~mixBus,
+        \input, ~mixBus.index,
         \out, 0
     ], target: ~outputGroup);
 


### PR DESCRIPTION
## Summary
- ensure the NodeProxy is routed using a concrete audio bus index when connecting it to the synth voice group
- pass explicit mix bus indices to the mix channel and output limiter synths so they read from the allocated bus correctly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd468a862c8333a71dc89a01d5e0e6