### PR TITLE
Ensure braids voicer routes into mix bus and remove extra window

### DIFF
--- a/config/transbus_sc1.scd
+++ b/config/transbus_sc1.scd
@@ -31,7 +31,7 @@
 };
 
 ~setupBraidsVoicer = { |voiceGroup, mixInputs, channelIndex = 0, defaultConfig|
-    var midiSource, midiUID, outputBus, proxy, roli, voicer, updatedConfig;
+    var midiSource, midiUID, outputBus, proxy, roli, voicer, updatedConfig, channelSynth;
 
     ~teardownBraidsVoicer.value;
 
@@ -69,6 +69,16 @@
     ));
 
     mixInputs[channelIndex] = updatedConfig;
+
+    if(~channelSynths.isArray and: { channelIndex >= 0 } and: { channelIndex < ~channelSynths.size }) {
+        channelSynth = ~channelSynths[channelIndex];
+        channelSynth.tryPerform(\set,
+            \inA, updatedConfig[\channels][0],
+            \inB, updatedConfig[\channels][1],
+            \isMono, updatedConfig[\isMono] ?? { 0 },
+            \useSoundIn, updatedConfig[\useSoundIn] ?? { 1 }
+        );
+    };
 
     ~braidsVoicer = voicer;
 };

--- a/main.scd
+++ b/main.scd
@@ -26,4 +26,3 @@ s.options.numInputBusChannels = 8;
 // ======================
 s.waitForBoot({ ~bootMixTable.value });
 
-s.makeWindow;

--- a/modules/mixer.scd
+++ b/modules/mixer.scd
@@ -89,8 +89,6 @@ SynthDef(\mixChannel, {
     ~inputGroup = Group.after(~voiceGroup);
     ~outputGroup = Group.after(~inputGroup);
 
-    ~setupBraidsVoicer.value(~voiceGroup, ~mixInputs, 0, ~defaultMixInputs[0]);
-
     ~channelStates = Array.fill(~mixInputs.size, {
         var eqState = IdentityDictionary.new;
         ~eqDefaults.keysValuesDo { |band, defaults|
@@ -128,6 +126,8 @@ SynthDef(\mixChannel, {
         \input, ~mixBus.index,
         \out, 0
     ], target: ~outputGroup);
+
+    ~setupBraidsVoicer.value(~voiceGroup, ~mixInputs, 0, ~defaultMixInputs[0]);
 
     ~setChannelGain = { |index, db|
         if((index >= 0) and: { index < ~channelSynths.size }) {


### PR DESCRIPTION
## Summary
- update the braids voicer setup to push its audio routing back into the mix channel when the synth array is available
- move the braids voicer setup call so the mixer channels exist before we adjust their inputs
- stop opening the default server window once the custom UI is created

## Testing
- not run (SuperCollider environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd4a1af2848333a9c91808b3537adf