### PR TITLE
Route roli synth output to first mixer channel

### DIFF
--- a/config/transbus_sc1.scd
+++ b/config/transbus_sc1.scd
@@ -57,7 +57,7 @@
         uid: midiUID
     );
 
-    ~makeVoice.value(midiUID, voicer, 0, outputBus.index);
+    ~makeRoliVoice.value(midiUID, voicer, 0, outputBus.index);
 
     updatedConfig = (defaultConfig ? ()).copy;
     updatedConfig.putAll((

--- a/modules/synth.scd
+++ b/modules/synth.scd
@@ -1,14 +1,26 @@
-SynthDef(\synth1,
-	{|
-	out=0, gate=1, freq, buff, amp, mod, rls=3, bend, pan, ctrl1, ctrl2
-	|
+SynthDef(\roli_kaivoY001,
+{|
+out=0, gate=1, freq, buff, amp=0, mod=0, rls=3, bend=0, pan=0, ctrl1, ctrl2
+|
 
-    var sig, env,
-	freq2 = freq * bend.midiratio;
+    var sig, env, rlpfsig, rbpfsig, lfo,
+freq2 = freq * bend.midiratio;
 
-	env = Env.adsr(0.1,0.3, 1, rls).kr(2,gate);
-	sig = SinOsc.ar(freq2);
+env = Env.adsr(0.1,0.3, 1, rls).kr(2,gate);
+lfo = SinOsc.ar(~tempo ? 1, 0, 1);
 
-	sig = sig  * env;
+sig = SelectX.ar(amp.squared.lag(0.1), [
+        SinOsc.ar(freq2),
+        Saw.ar(freq2),
+    ]);
+
+sig = sig  * env;
+rlpfsig = BMoog.ar(sig, SinOsc.ar(mod.linexp(0,1,1,4)).range(1000, 1333) * amp.linexp(0,1,0.15,1).lag(0.1), 0.33, 0 );
+rbpfsig = Friction.ar(
+BMoog.ar(sig, mod.linexp(0,1,5e3,18e3), 0.33, 3),
+friction: mod.linlin(0,1,0.001,0.03).lag(0.1), mass: amp.linexp(0,1,0.2,5.25).lag(0.1),
+);
+sig = Mix.ar([rlpfsig, rbpfsig * mod.squared.lag(0.2)]*0.5);
+sig = (sig).tanh;
     Out.ar(out, Pan2.ar(sig, Rand(-1,1) * pan, amp.linexp(0,1,0.01,0.9).lag(rls)));
-	}).add;
+}).add;

--- a/modules/voicer.scd
+++ b/modules/voicer.scd
@@ -1,70 +1,63 @@
-~makeVoice  =
-        {|uid, voicer, bank, out|
-        var midiDefs = IdentityDictionary.new;
+~makeRoliVoice =
+    {|uid, voicer, bank, out|
+    var midiDefs = IdentityDictionary.new;
 
-        voicer.indivParams;
+    voicer.indivParams;
 
-        voicer.roli.prime(\synth1);
+    voicer.roli.prime(\roli_kaivoY001);
 
-        voicer.makeNote = { |q, chan, note = 60, vel = 64|
-                var velocity = vel.max(1) / 127; // avoid a zero velocity on note-on
-                voicer.roli.put(chan, [
-                        \freq, (note + ~rootNote).keyToDegree(~scale,12).degreeToKey(~scale).midicps,
-                        \amp, velocity,
-                        \gate, 1,
-                        \mod, 0,
-                        \bend, 0,
-                        \pan, 0,
-                        \out, out
-                        ]);
+    voicer.makeNote = { |q, chan, note = 60, vel = 64|
+        var velocity = vel.max(1) / 127; // avoid a zero velocity on note-on
+        voicer.roli.put(chan, [
+            \freq, (note + ~rootNote).keyToDegree(~scale,12).degreeToKey(~scale).midicps,
+            \amp, velocity,
+            \mod, 0,
+            \bend, 0,
+            \pan, 0,
+            \gate, 1,
+            \out, out
+        ]);
+    };
+    voicer.endNote = { |q, chan|
+        var obj = voicer.roli.proxy.objects[chan];
+        if (obj.notNil) { obj.set(\gate, 0) };
+    };
+
+    voicer.setTouch = { |q, chan=0, touchval = 64|
+        var obj = voicer.roli.proxy.objects[chan];
+        if (obj.notNil) { obj.set(\amp, (touchval/127)) };
+    };
+    voicer.setSlide = { |q, chan=0, slide = 0|
+        var obj = voicer.roli.proxy.objects[chan];
+        if (obj.notNil) { obj.set(\mod, (slide/127)) };
+    };
+    voicer.setBend = { |q, chan=0, bendval = 0|
+        var obj = voicer.roli.proxy.objects[chan];
+        if (obj.notNil) {
+            obj.set(\bend, bendval.linlin(0, 16383, -36, 36))
         };
-        voicer.endNote = { |q, chan|
-                var obj = voicer.roli.proxy.objects[chan];
-                if (obj.notNil) { obj.set(\gate, 0) };
-        };
+    };
 
-        voicer.setTouch = { |q, chan=0, touchval = 64|
-                var obj = voicer.roli.proxy.objects[chan];
-                if (obj.notNil) { obj.set(\amp, (touchval/127)) };
-        };
-        voicer.setSlide = { |q, chan=0, slide = 0|
-                var obj = voicer.roli.proxy.objects[chan];
-                // "slide: % % %\n".postf(chan, slide);
-                if (obj.notNil) { obj.set(\mod, (slide/127)) };
-        };
-        voicer.setBend = { |q, chan=0, bendval = 0|
-                var obj = voicer.roli.proxy.objects[chan];
-                if (obj.notNil) { obj.set(\bend,
-                        bendval.linlin(0, 16383, -36, 36)) };
-        };
+    midiDefs[\noteOn] = MIDIdef.noteOn(\roliOn ++ out, { |vel, noteNum, chan|
+        voicer.makeNote(chan, noteNum, vel);
+    },srcID:uid).enable;
 
-        midiDefs[\noteOn] = MIDIdef.noteOn(\roliOn ++ out, { |vel, noteNum, chan|
-                "noteOn: % % %\n".postf(noteNum, vel, chan);
-                voicer.makeNote(chan, noteNum, vel);
-        },srcID:uid).enable;
+    midiDefs[\noteOff] = MIDIdef.noteOff(\roliOff ++ out, { |vel, noteNum, chan|
+        voicer.endNote(chan, noteNum);
+    },srcID:uid).enable;
 
-        midiDefs[\noteOff] = MIDIdef.noteOff(\roliOff ++ out, { |vel, noteNum, chan|
-                // "noteOff: % % %\n".postf(noteNum, vel, chan);
-                voicer.endNote(chan, noteNum);
-        },srcID:uid).enable;
+    midiDefs[\slide] = MIDIdef.cc(\roliSlide ++ out, { |val, ccnum, chan|
+        voicer.setSlide(chan, val);
+    },1,srcID:uid).enable;
 
-        midiDefs[\slide] = MIDIdef.cc(\roliSlide ++ out, { |val, ccnum, chan|
-                // ("slide " + ccnum  + val + chan).postln;
-                voicer.setSlide(chan, val);
-        },1,srcID:uid).enable;
+    midiDefs[\touch] = MIDIdef.touch(\roliTouch ++ out, { |val, chan, src|
+        voicer.setTouch(chan, val);
+    },srcID:uid).enable;
+    midiDefs[\bend] = MIDIdef.bend(\roliBend ++ out, { |bend, chan|
+        voicer.setBend(chan, bend);
+    },srcID:uid).enable;
 
-        midiDefs[\touch] = MIDIdef.touch(\roliTouch ++ out, { |val, chan, src|
-                voicer.setTouch(chan, val);
-        },srcID:uid).enable;
-        midiDefs[\bend] = MIDIdef.bend(\roliBend ++ out, { |bend, chan|
-                // "bend: % %\n".postf(bend, chan);
-                voicer.setBend(chan, bend);
-        },srcID:uid).enable;
-        // MIDIdef.program(\roliProgram ++ out, { |prog, chan|
-        //      "program: % %\n".postf(prog, chan);
-        //      voicer.roli.prime(~presets[bank][prog])
-        // },srcID:uid).enable;
-        voicer.midiDefs = midiDefs;
-        voicer.uid = uid;
-        voicer.out = out;
-        };
+    voicer.midiDefs = midiDefs;
+    voicer.uid = uid;
+    voicer.out = out;
+};


### PR DESCRIPTION
## Summary
- replace the placeholder synth definition with the roli_kaivoY001 patch
- update the voicer to drive the new synth parameters and MIDI gestures
- configure the TransBus setup to pipe the voicer output into mixer channel 1

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd4dd43aa483339ff3217f1af5ef1e