### PR TITLE
Fix ROLI voicing by managing synth instances directly

### DIFF
--- a/config/transbus_sc1.scd
+++ b/config/transbus_sc1.scd
@@ -13,11 +13,15 @@
         current.midiDefs !? { |defs|
             defs.values.do { |def| def.tryPerform(\free); };
         };
-        current.roli.tryPerform(\releaseAll);
-        current.roli.tryPerform(\stop);
-        current.proxy.tryPerform(\stop);
-        current.proxy.tryPerform(\clear);
-        current.proxy.tryPerform(\free);
+        current.voices !? { |voiceDict|
+            voiceDict.values.do(_.tryPerform(\release, 0.1));
+            voiceDict.clear;
+        };
+        current.proxy !? { |proxy|
+            proxy.tryPerform(\stop);
+            proxy.tryPerform(\clear);
+            proxy.tryPerform(\free);
+        };
         current.bus.tryPerform(\free);
     };
     ~braidsVoicer = nil;
@@ -30,7 +34,7 @@
 };
 
 ~setupBraidsVoicer = { |voiceGroup, mixInputs, channelIndex = 0, defaultConfig|
-    var midiSource, midiUID, outputBus, proxy, roli, voicer, updatedConfig, channelSynth;
+    var midiSource, midiUID, outputBus, voicer, updatedConfig, channelSynth;
 
     ~teardownBraidsVoicer.value;
 
@@ -44,15 +48,10 @@
     midiUID = midiSource.tryPerform(\uid);
 
     outputBus = Bus.audio(s, 2);
-    proxy = NodeProxy.audio(s, 2);
-    proxy.play(outputBus.index, 2, voiceGroup);
-    roli = NPVoicerL(proxy, [\freq, \amp, \mod, \bend, \out]);
 
     voicer = (
-        proxy: proxy,
-        roli: roli,
+        group: voiceGroup,
         bus: outputBus,
-        indivParams: [\freq, \amp, \mod, \bend, \out],
         midiSource: midiSource,
         uid: midiUID
     );

--- a/modules/voicer.scd
+++ b/modules/voicer.scd
@@ -1,61 +1,63 @@
 ~makeRoliVoice =
     {|uid, voicer, bank, out|
     var midiDefs = IdentityDictionary.new;
+    var voices = IdentityDictionary.new;
 
-    voicer.indivParams;
-
-    voicer.roli.prime(\roli_kaivoY001);
+    voicer.voices = voices;
 
     voicer.makeNote = { |q, chan, note = 60, vel = 64|
         var velocity = vel.max(1) / 127; // avoid a zero velocity on note-on
-        voicer.roli.put(chan, [
-            \freq, (note + ~rootNote).keyToDegree(~scale,12).degreeToKey(~scale).midicps,
+        var freq = (note + ~rootNote).keyToDegree(~scale, 12).degreeToKey(~scale).midicps;
+        var existing = voices[chan];
+
+        existing.tryPerform(\release, 0.1);
+
+        voices[chan] = Synth(\roli_kaivoY001, [
+            \freq, freq,
             \amp, velocity,
             \mod, 0,
             \bend, 0,
             \pan, 0,
             \gate, 1,
             \out, out
-        ]);
+        ], target: voicer.group ?? { s.defaultGroup });
     };
     voicer.endNote = { |q, chan|
-        var obj = voicer.roli.proxy.objects[chan];
-        if (obj.notNil) { obj.set(\gate, 0) };
+        var synth = voices.removeAt(chan);
+        synth.tryPerform(\release, 0.1);
     };
 
-    voicer.setTouch = { |q, chan=0, touchval = 64|
-        var obj = voicer.roli.proxy.objects[chan];
-        if (obj.notNil) { obj.set(\amp, (touchval/127)) };
+    voicer.setTouch = { |q, chan = 0, touchval = 64|
+        var synth = voices[chan];
+        synth.tryPerform(\set, \amp, (touchval / 127));
     };
-    voicer.setSlide = { |q, chan=0, slide = 0|
-        var obj = voicer.roli.proxy.objects[chan];
-        if (obj.notNil) { obj.set(\mod, (slide/127)) };
+    voicer.setSlide = { |q, chan = 0, slide = 0|
+        var synth = voices[chan];
+        synth.tryPerform(\set, \mod, (slide / 127));
     };
-    voicer.setBend = { |q, chan=0, bendval = 0|
-        var obj = voicer.roli.proxy.objects[chan];
-        if (obj.notNil) {
-            obj.set(\bend, bendval.linlin(0, 16383, -36, 36))
-        };
+    voicer.setBend = { |q, chan = 0, bendval = 0|
+        var synth = voices[chan];
+        synth.tryPerform(\set, \bend, bendval.linlin(0, 16383, -36, 36));
     };
 
     midiDefs[\noteOn] = MIDIdef.noteOn(\roliOn ++ out, { |vel, noteNum, chan|
         voicer.makeNote(chan, noteNum, vel);
-    },srcID:uid).enable;
+    }, srcID: uid).enable;
 
     midiDefs[\noteOff] = MIDIdef.noteOff(\roliOff ++ out, { |vel, noteNum, chan|
         voicer.endNote(chan, noteNum);
-    },srcID:uid).enable;
+    }, srcID: uid).enable;
 
     midiDefs[\slide] = MIDIdef.cc(\roliSlide ++ out, { |val, ccnum, chan|
         voicer.setSlide(chan, val);
-    },1,srcID:uid).enable;
+    }, 1, srcID: uid).enable;
 
     midiDefs[\touch] = MIDIdef.touch(\roliTouch ++ out, { |val, chan, src|
         voicer.setTouch(chan, val);
-    },srcID:uid).enable;
+    }, srcID: uid).enable;
     midiDefs[\bend] = MIDIdef.bend(\roliBend ++ out, { |bend, chan|
         voicer.setBend(chan, bend);
-    },srcID:uid).enable;
+    }, srcID: uid).enable;
 
     voicer.midiDefs = midiDefs;
     voicer.uid = uid;


### PR DESCRIPTION
## Summary
- replace the NPVoicer-based ROLI voice setup with direct Synth management to avoid nil latency errors
- update the teardown routine to release the manually created voices and keep the bus cleanup intact

## Testing
- not run (environment only provides SuperCollider scripts)


------
https://chatgpt.com/codex/tasks/task_e_68dd4f8c5768833387cd72405bf62562