### PR TITLE
Fix voicer MIDI callbacks to use stored functions

### DIFF
--- a/modules/voicer.scd
+++ b/modules/voicer.scd
@@ -5,7 +5,7 @@
 
     voicer.voices = voices;
 
-    voicer.makeNote = { |q, chan, note = 60, vel = 64|
+    voicer[\makeNote] = { |q, chan, note = 60, vel = 64|
         var velocity = vel.max(1) / 127; // avoid a zero velocity on note-on
         var freq = (note + ~rootNote).keyToDegree(~scale, 12).degreeToKey(~scale).midicps;
         var existing = voices[chan];
@@ -22,41 +22,41 @@
             \out, out
         ], target: voicer.group ?? { s.defaultGroup });
     };
-    voicer.endNote = { |q, chan|
+    voicer[\endNote] = { |q, chan|
         var synth = voices.removeAt(chan);
         synth.tryPerform(\release, 0.1);
     };
 
-    voicer.setTouch = { |q, chan = 0, touchval = 64|
+    voicer[\setTouch] = { |q, chan = 0, touchval = 64|
         var synth = voices[chan];
         synth.tryPerform(\set, \amp, (touchval / 127));
     };
-    voicer.setSlide = { |q, chan = 0, slide = 0|
+    voicer[\setSlide] = { |q, chan = 0, slide = 0|
         var synth = voices[chan];
         synth.tryPerform(\set, \mod, (slide / 127));
     };
-    voicer.setBend = { |q, chan = 0, bendval = 0|
+    voicer[\setBend] = { |q, chan = 0, bendval = 0|
         var synth = voices[chan];
         synth.tryPerform(\set, \bend, bendval.linlin(0, 16383, -36, 36));
     };
 
     midiDefs[\noteOn] = MIDIdef.noteOn(\roliOn ++ out, { |vel, noteNum, chan|
-        voicer.makeNote(chan, noteNum, vel);
+        voicer[\makeNote].tryPerform(\value, voicer, chan, noteNum, vel);
     }, srcID: uid).enable;
 
     midiDefs[\noteOff] = MIDIdef.noteOff(\roliOff ++ out, { |vel, noteNum, chan|
-        voicer.endNote(chan, noteNum);
+        voicer[\endNote].tryPerform(\value, voicer, chan, noteNum);
     }, srcID: uid).enable;
 
     midiDefs[\slide] = MIDIdef.cc(\roliSlide ++ out, { |val, ccnum, chan|
-        voicer.setSlide(chan, val);
+        voicer[\setSlide].tryPerform(\value, voicer, chan, val);
     }, 1, srcID: uid).enable;
 
     midiDefs[\touch] = MIDIdef.touch(\roliTouch ++ out, { |val, chan, src|
-        voicer.setTouch(chan, val);
+        voicer[\setTouch].tryPerform(\value, voicer, chan, val);
     }, srcID: uid).enable;
     midiDefs[\bend] = MIDIdef.bend(\roliBend ++ out, { |bend, chan|
-        voicer.setBend(chan, bend);
+        voicer[\setBend].tryPerform(\value, voicer, chan, bend);
     }, srcID: uid).enable;
 
     voicer.midiDefs = midiDefs;


### PR DESCRIPTION
## Summary
- store voicer callbacks under dictionary keys instead of relying on message sends
- invoke the callbacks safely when MIDI events arrive to avoid missing method errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd50e2bb8c83338174afcb3fac3b15