### PR TITLE
Guard MIDI voicer against missing target group

### DIFF
--- a/modules/voicer.scd
+++ b/modules/voicer.scd
@@ -10,12 +10,21 @@
         var freq = (note + ~rootNote).keyToDegree(~scale, 12).degreeToKey(~scale).midicps;
         var existing = voices[chan];
         var targetGroup = voicer.at(\group);
+        var server;
 
         existing.tryPerform(\release, 0.1);
 
         targetGroup = targetGroup ?? { s.defaultGroup };
 
-        if(targetGroup.isNil) {
+        server = targetGroup.tryPerform(\server);
+
+        if(server.isNil) {
+            targetGroup = Group.head(s);
+            voicer.put(\group, targetGroup);
+            server = targetGroup.tryPerform(\server);
+        };
+
+        if(targetGroup.isNil or: { server.isNil }) {
             ("Aucun groupe de destination valide pour la voix MIDI (canal %).".format(chan)).warn;
             ^nil;
         };


### PR DESCRIPTION
## Summary
- ensure the Roli voicer checks that its destination group has an attached server before spawning a synth
- recreate and store a fresh group if the previous one was freed to avoid nil target errors

## Testing
- not run (SuperCollider environment not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dd53ba0ee88333934f29ff8c14c265