### PR TITLE
Fix ROLI voicer setup and remove first mixer channel

### DIFF
--- a/main.scd
+++ b/main.scd
@@ -38,12 +38,11 @@ s.latency = 0.1;
 	};
 	~initMidi.value;
 	s.sync;
-	~voicer = ~voicer ? ();
-	~voicer.synth = NPVoicer( Ndef(\roli));
-	s.sync;
-	~makeVoice.value(~uidRoli1, ~voicer, 0,0);
-	s.sync;
-	~voicer.synth.prime(\synth1);
+        ~voicer = ~voicer ? ();
+        ~voicer.roli = NPVoicer(Ndef(\roli));
+        s.sync;
+        ~makeVoice.value(~uidRoli1, ~voicer, 0,0);
+        s.sync;
 };
 
 // ======================

--- a/modules/mixer.scd
+++ b/modules/mixer.scd
@@ -7,10 +7,9 @@ SynthDef(\outputLimiter, { |input = 0, out = 0|
 
 // ================= Mixage et gestion des bus =================
 
-// Définitions des tranches d'entrée : Synth 1, 3/4, 5/6, 7/8
+// Définitions des tranches d'entrée : 3/4, 5/6, 7/8
 
 ~defaultMixInputs = [
-    (label: "Synth 1", channels: [0, 1], isMono: 0, useSoundIn: 0),
     (label: "3 / 4", channels: [2, 3], isMono: 0, useSoundIn: 1),
     (label: "5 / 6", channels: [4, 5], isMono: 0, useSoundIn: 1),
     (label: "7 / 8", channels: [6, 7], isMono: 0, useSoundIn: 1)
@@ -72,7 +71,7 @@ SynthDef(\mixChannel, {
         };
     };
 
-    ~teardownBraidsVoicer.value;
+    ~teardownBraidsVoicer.tryPerform(\value);
 
     [~voiceGroup, ~inputGroup, ~outputGroup].do(_.tryPerform(\free));
     ~mixBus.tryPerform(\free);
@@ -127,7 +126,7 @@ SynthDef(\mixChannel, {
         \out, 0
     ], target: ~outputGroup);
 
-    ~setupBraidsVoicer.value(~voiceGroup, ~mixInputs, 0, ~defaultMixInputs[0]);
+    // Aucun voicer externe n'est configuré automatiquement pour la première tranche.
 
     ~setChannelGain = { |index, db|
         if((index >= 0) and: { index < ~channelSynths.size }) {
@@ -178,7 +177,7 @@ SynthDef(\mixChannel, {
                 if(item.isKindOf(Array)) { item.do(_.tryPerform(\free)) } { item.tryPerform(\free) };
             };
         };
-        ~teardownBraidsVoicer.value;
+        ~teardownBraidsVoicer.tryPerform(\value);
         [~mixBus].do { |bus| bus.tryPerform(\free) };
         [~voiceGroup, ~inputGroup, ~outputGroup].do(_.tryPerform(\free));
     });

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -13,7 +13,7 @@
     ];
 
     if(~mixWindow.notNil) { ~mixWindow.close };
-    window = Window("MixTable - 4 voies", Rect(100, 100, 960, 560));
+    window = Window("MixTable - 3 voies", Rect(100, 100, 960, 560));
     if(window.respondsTo(\resizable_)) {
         window.resizable_(true);
     } {

--- a/modules/voicer.scd
+++ b/modules/voicer.scd
@@ -1,36 +1,43 @@
 ~makeVoice =
 	{|uid, voicer, bank, out|
 
-	voicer.indivParams;
+        var roliVoicer;
 
-	voicer.roli.prime(\roli_kaivoY001);
+        roliVoicer = voicer[\roli];
+        if(roliVoicer.isNil) {
+                Error("Aucun voicer ROLI initialisé").throw;
+        };
 
-	voicer.makeNote = { |q, chan, note = 60, vel = 64|
-		voicer.roli.put(chan, [
-			\freq, (note + ~rootNote).keyToDegree(~scale,12).degreeToKey(~scale).midicps,
-			\vel, (vel/127),
-			\out, out
-			]);
-	};
-	voicer.endNote = { |q, chan|
-		var obj = voicer.roli.proxy.objects[chan];
-		if (obj.notNil) { obj.set(\gate, 0) };
-	};
+        roliVoicer.indivParams;
 
-	voicer.setTouch = { |q, chan=0, touchval = 64|
-		var obj = voicer.roli.proxy.objects[chan];
-		if (obj.notNil) { obj.set(\amp, (touchval/127)) };
-	};
-	voicer.setSlide = { |q, chan=0, slide = 0|
-		var obj = voicer.roli.proxy.objects[chan];
-		// "slide: % % %\n".postf(chan, slide);
-		if (obj.notNil) { obj.set(\mod, (slide/127)) };
-	};
-	voicer.setBend = { |q, chan=0, bendval = 0|
-		var obj = voicer.roli.proxy.objects[chan];
-		if (obj.notNil) { obj.set(\bend,
-			bendval.linlin(0, 16383, -36, 36)) };o
-	};
+        roliVoicer.prime(\roli_kaivoY001);
+
+        voicer.makeNote = { |q, chan, note = 60, vel = 64|
+                roliVoicer.put(chan, [
+                        \freq, (note + ~rootNote).keyToDegree(~scale,12).degreeToKey(~scale).midicps,
+                        \vel, (vel/127),
+                        \out, out
+                        ]);
+        };
+        voicer.endNote = { |q, chan|
+                var obj = roliVoicer.proxy.objects[chan];
+                if (obj.notNil) { obj.set(\gate, 0) };
+        };
+
+        voicer.setTouch = { |q, chan=0, touchval = 64|
+                var obj = roliVoicer.proxy.objects[chan];
+                if (obj.notNil) { obj.set(\amp, (touchval/127)) };
+        };
+        voicer.setSlide = { |q, chan=0, slide = 0|
+                var obj = roliVoicer.proxy.objects[chan];
+                // "slide: % % %\n".postf(chan, slide);
+                if (obj.notNil) { obj.set(\mod, (slide/127)) };
+        };
+        voicer.setBend = { |q, chan=0, bendval = 0|
+                var obj = roliVoicer.proxy.objects[chan];
+                if (obj.notNil) { obj.set(\bend,
+                        bendval.linlin(0, 16383, -36, 36)) };
+        };
 
 	MIDIdef.noteOn(\roliOn ++ out, { |vel, noteNum, chan|
 		"noteOn: % % %\n".postf(noteNum, vel, chan);


### PR DESCRIPTION
## Summary
- store the ROLI NPVoicer in the shared voicer environment and guard access to it during MIDI handling
- update mixer setup to remove the first soundcard strip and avoid configuring an external voicer automatically
- refresh the UI title to match the reduced three-channel mixer layout

## Testing
- not run (SuperCollider environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd59d79e6483338f8bf7fb0b59621d