### PR TITLE
Fix MIDI source detection

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -12,8 +12,14 @@ if(MIDIClient.initialized.not) {
     MIDIIn.connectAll;
 
     matchDevice = { |src|
-        src.notNil and: {
-            src.device == "TransBus" and: { src.name == "SC1" }
+        var source;
+
+        source = MIDIClient.sources.detect { |endpoint|
+            endpoint.uid == src
+        };
+
+        source.notNil and: {
+            source.device == "TransBus" and: { source.name == "SC1" }
         }
     };
 


### PR DESCRIPTION
## Summary
- look up the MIDI endpoint from the source id before checking its name and device

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd6bb6e57083339073c6107dbc2a99