### PR TITLE
Refactor MIDI synth handling

### DIFF
--- a/main.scd
+++ b/main.scd
@@ -12,6 +12,7 @@ s.options.numInputBusChannels = 8;
 // ======================
 ~bootMixTable = {
     ("modules/synths.scd").loadRelative;
+    ("modules/midi_synths.scd").loadRelative;
     ("modules/midi.scd").loadRelative;
     ("modules/ui.scd").loadRelative;
 

--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -2,11 +2,38 @@ if(MIDIClient.initialized.not) {
     MIDIClient.init;
 };
 
+~midiNoteKey = { |channel, note| "%:%".format(channel, note) };
+
+~releaseMidiNote = { |channel, note|
+    var dict = ~midiActiveSynths;
+    var key, synth;
+
+    if(dict.isNil) { ^nil };
+
+    key = ~midiNoteKey.(channel, note);
+    synth = dict.removeAt(key);
+
+    if(synth.notNil) {
+        synth.tryPerform(\set, \gate, 0);
+        synth.tryPerform(\release);
+    };
+};
+
 ~setupMidi = {
     var matchDevice;
 
     ~midiResponders.tryPerform(\do, _.tryPerform(\free));
     ~midiResponders = List.new;
+
+    if(~midiActiveSynths.notNil) {
+        ~midiActiveSynths.valuesDo { |synth|
+            synth.tryPerform(\set, \gate, 0);
+            synth.tryPerform(\release);
+            synth.tryPerform(\free);
+        };
+    };
+
+    ~midiActiveSynths = Dictionary.new;
 
     MIDIIn.disconnectAll;
     MIDIIn.connectAll;
@@ -25,19 +52,42 @@ if(MIDIClient.initialized.not) {
 
     ~midiResponders.add(MIDIFunc.noteOn({ |velocity, note, channel, src|
         if(matchDevice.(src)) {
-            var freq = note.midicps;
-            var amp = velocity.linlin(1, 127, 0.02, 0.5);
-            var outBus = ~directBus ?? { 0 };
-            Synth(\percussiveSine, [
-                \freq, freq,
-                \amp, amp,
-                \out, outBus
-            ]);
+            if(velocity <= 0) {
+                ~releaseMidiNote.(channel, note);
+            } {
+                var freq = note.midicps;
+                var amp = velocity.linlin(1, 127, 0.02, 0.5);
+                var outBus = ~directBus ?? { 0 };
+                var key = ~midiNoteKey.(channel, note);
+                var synth;
+
+                ~releaseMidiNote.(channel, note);
+
+                synth = Synth(\percussiveSine, [
+                    \freq, freq,
+                    \amp, amp,
+                    \out, outBus
+                ]);
+
+                ~midiActiveSynths[key] = synth;
+            };
+        };
+    }));
+
+    ~midiResponders.add(MIDIFunc.noteOff({ |velocity, note, channel, src|
+        if(matchDevice.(src)) {
+            ~releaseMidiNote.(channel, note);
         };
     }));
 
     CmdPeriod.doOnce({
         ~midiResponders.tryPerform(\do, _.tryPerform(\free));
         ~midiResponders = nil;
+        ~midiActiveSynths.tryPerform(\valuesDo, { |synth|
+            synth.tryPerform(\set, \gate, 0);
+            synth.tryPerform(\release);
+            synth.tryPerform(\free);
+        });
+        ~midiActiveSynths = nil;
     });
 };

--- a/modules/midi_synths.scd
+++ b/modules/midi_synths.scd
@@ -1,0 +1,7 @@
+// ================= Synthés pour les entrées MIDI =================
+SynthDef(\percussiveSine, { |out = 0, freq = 440, amp = 0.2, attack = 0.005, release = 0.35|
+    var env = Env.perc(attack.max(0.001), release.max(0.01), 1, curve: -4);
+    var envGen = EnvGen.kr(env, doneAction: 2);
+    var sig = SinOsc.ar(freq) * envGen * amp;
+    Out.ar(out, sig ! 2);
+}).add;

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -5,15 +5,7 @@ SynthDef(\outputLimiter, { |input = 0, out = 0|
     Out.ar(out, limited.tanh);
 }).add;
 
-// ================= Bus direct et synthé percussif =================
-SynthDef(\percussiveSine, { |out = 0, freq = 440, amp = 0.2, attack = 0.005, release = 0.35|
-    var env = Env.perc(attack.max(0.001), release.max(0.01), 1, curve: -4);
-    var envGen = EnvGen.kr(env, doneAction: 2);
-    var sig = SinOsc.ar(freq) * envGen * amp;
-    Out.ar(out, sig ! 2);
-}).add;
-
-// ================= Mixage et gestion des bus =================
+// ================= Bus direct =================
 
 // Définitions des tranches d'entrée : 1 (mono), 3/4, 5/6, 7/8
 ~mixInputs = [


### PR DESCRIPTION
## Summary
- move the MIDI responder synth definition into its own module and load it during boot
- track active MIDI responder synth instances and add note-off handling for future ADSR-based synths
- ensure MIDI synth instances are cleaned up when reinitializing or stopping the server

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd6edec32883339d2db520dde2b7dd