### PR TITLE
Add MIDI aftertouch responder for percussive sine synth volume

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -34,6 +34,7 @@ if(MIDIClient.initialized.not) {
     };
 
     ~midiActiveSynths = Dictionary.new;
+    ~midiAftertouchLevels = IdentityDictionary.new;
 
     MIDIIn.disconnectAll;
     MIDIIn.connectAll;
@@ -66,7 +67,8 @@ if(MIDIClient.initialized.not) {
                 synth = Synth(\percussiveSine, [
                     \freq, freq,
                     \amp, amp,
-                    \out, outBus
+                    \out, outBus,
+                    \aftertouchAmp, (~midiAftertouchLevels[channel] ?? { 1 })
                 ]);
 
                 ~midiActiveSynths[key] = synth;
@@ -80,6 +82,21 @@ if(MIDIClient.initialized.not) {
         };
     }));
 
+    ~midiResponders.add(MIDIFunc.afterTouch({ |value, channel, src|
+        if(matchDevice.(src)) {
+            var level = value.linlin(0, 127, 0, 1);
+            var prefix = channel.asString ++ ":";
+
+            ~midiAftertouchLevels[channel] = level;
+
+            ~midiActiveSynths.keysValuesDo { |key, synth|
+                if(key.beginsWith(prefix)) {
+                    synth.tryPerform(\set, \aftertouchAmp, level);
+                };
+            };
+        };
+    }));
+
     CmdPeriod.doOnce({
         ~midiResponders.tryPerform(\do, _.tryPerform(\free));
         ~midiResponders = nil;
@@ -89,5 +106,6 @@ if(MIDIClient.initialized.not) {
             synth.tryPerform(\free);
         });
         ~midiActiveSynths = nil;
+        ~midiAftertouchLevels = nil;
     });
 };

--- a/modules/midi_synths.scd
+++ b/modules/midi_synths.scd
@@ -1,7 +1,7 @@
 // ================= Synthés pour les entrées MIDI =================
-SynthDef(\percussiveSine, { |out = 0, freq = 440, amp = 0.2, attack = 0.005, release = 0.35|
+SynthDef(\percussiveSine, { |out = 0, freq = 440, amp = 0.2, attack = 0.005, release = 0.35, aftertouchAmp = 1|
     var env = Env.perc(attack.max(0.001), release.max(0.01), 1, curve: -4);
     var envGen = EnvGen.kr(env, doneAction: 2);
-    var sig = SinOsc.ar(freq) * envGen * amp;
+    var sig = SinOsc.ar(freq) * envGen * amp * aftertouchAmp;
     Out.ar(out, sig ! 2);
 }).add;


### PR DESCRIPTION
## Summary
- add an aftertouch-controlled gain parameter to the percussive sine SynthDef
- store per-channel aftertouch values and update active notes through a new MIDI responder

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd75f765908333883bbc7e6c610148