### PR TITLE
Fix MIDI active synth iteration

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -68,7 +68,7 @@ if(MIDIClient.initialized.not) {
     ~midiResponders = List.new;
 
     if(~midiActiveSynths.notNil) {
-        ~midiActiveSynths.valuesDo { |synth|
+        ~midiActiveSynths.do { |key, synth|
             synth.tryPerform(\set, \gate, 0);
             synth.tryPerform(\release);
             synth.tryPerform(\free);
@@ -156,7 +156,7 @@ if(MIDIClient.initialized.not) {
     CmdPeriod.doOnce({
         ~midiResponders.tryPerform(\do, _.tryPerform(\free));
         ~midiResponders = nil;
-        ~midiActiveSynths.tryPerform(\valuesDo, { |synth|
+        ~midiActiveSynths.tryPerform(\do, { |key, synth|
             synth.tryPerform(\set, \gate, 0);
             synth.tryPerform(\release);
             synth.tryPerform(\free);


### PR DESCRIPTION
## Summary
- replace Dictionary `valuesDo` calls with `do` during MIDI setup and cleanup
- prevent doesNotUnderstand errors when resetting active synths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd78870bf08333a8720849378d49db