### PR TITLE
Fix aftertouch responder

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -124,7 +124,7 @@ if(MIDIClient.initialized.not) {
         };
     }));
 
-    ~midiResponders.add(MIDIFunc.afterTouch({ |value, channel, src|
+    ~midiResponders.add(MIDIFunc.touch({ |value, channel, src|
         if(matchDevice.(src)) {
             var level = value.linlin(0, 127, 0, 1);
             var prefix = channel.asString ++ ":";


### PR DESCRIPTION
## Summary
- replace the nonexistent `MIDIFunc.afterTouch` responder with the correct channel aftertouch handler `MIDIFunc.touch`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd7910efc48333828cf034340cc267