### PR TITLE
Fix MIDIFunc polytouch responder name

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -142,7 +142,7 @@ if(MIDIClient.initialized.not) {
         };
     }));
 
-    ~midiResponders.add(MIDIFunc.polyTouch({ |value, note, channel, src|
+    ~midiResponders.add(MIDIFunc.polytouch({ |value, note, channel, src|
         if(matchDevice.(src)) {
             var level = value.linlin(0, 127, 0, 1);
             var key = ~midiNoteKey.(channel, note);


### PR DESCRIPTION
## Summary
- update the MIDI polyphonic aftertouch responder to call the correct MIDIFunc.polytouch method

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd79a9415c8333bd38352eb1ec39e7