### PR TITLE
Add Roli aftertouch control for percussive sine synth

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -7,6 +7,10 @@ if(MIDIClient.initialized.not) {
 
     ~midiResponders.tryPerform(\do, _.tryPerform(\free));
     ~midiResponders = List.new;
+    ~roliSineVoices.tryPerform(\do, { |synth|
+        synth.tryPerform(\free);
+    });
+    ~roliSineVoices = IdentityDictionary.new;
 
     MIDIIn.disconnectAll;
     MIDIIn.connectAll;
@@ -28,11 +32,46 @@ if(MIDIClient.initialized.not) {
             var freq = note.midicps;
             var amp = velocity.linlin(1, 127, 0.02, 0.5);
             var outBus = ~directBus ?? { 0 };
-            Synth(\percussiveSine, [
+            var synth;
+            synth = Synth(\percussiveSine, [
                 \freq, freq,
                 \amp, amp,
                 \out, outBus
             ]);
+            ~roliSineVoices[note] = synth;
+            synth.onFree({
+                {
+                    ~roliSineVoices.removeAt(note);
+                }.defer;
+            });
+        };
+    }));
+
+    ~midiResponders.add(MIDIFunc.polyTouch({ |pressure, note, channel, src|
+        if(matchDevice.(src)) {
+            var synth = ~roliSineVoices[note];
+            var mod = pressure.linlin(0, 127, 0, 1).clip(0, 1);
+            if(synth.notNil) {
+                synth.tryPerform(\set, \modAmp, mod);
+            };
+        };
+    }));
+
+    ~midiResponders.add(MIDIFunc.touch({ |pressure, channel, src|
+        if(matchDevice.(src)) {
+            var mod = pressure.linlin(0, 127, 0, 1).clip(0, 1);
+            ~roliSineVoices.do { |voice|
+                voice.tryPerform(\set, \modAmp, mod);
+            };
+        };
+    }));
+
+    ~midiResponders.add(MIDIFunc.noteOff({ |velocity, note, channel, src|
+        if(matchDevice.(src)) {
+            var synth = ~roliSineVoices.removeAt(note);
+            if(synth.notNil) {
+                synth.tryPerform(\set, \modAmp, 0);
+            };
         };
     }));
 

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -6,10 +6,10 @@ SynthDef(\outputLimiter, { |input = 0, out = 0|
 }).add;
 
 // ================= Bus direct et synthé percussif =================
-SynthDef(\percussiveSine, { |out = 0, freq = 440, amp = 0.2, attack = 0.005, release = 0.35|
+SynthDef(\percussiveSine, { |out = 0, freq = 440, amp = 0.2, attack = 0.005, release = 0.35, modAmp = 1|
     var env = Env.perc(attack.max(0.001), release.max(0.01), 1, curve: -4);
     var envGen = EnvGen.kr(env, doneAction: 2);
-    var sig = SinOsc.ar(freq) * envGen * amp;
+    var sig = SinOsc.ar(freq) * envGen * amp * modAmp;
     Out.ar(out, sig ! 2);
 }).add;
 


### PR DESCRIPTION
## Summary
- add a modulation amplitude control to the percussive sine SynthDef so pressure can scale output level
- track active Roli voices and bind poly aftertouch and channel pressure to the percussive sine volume
- ensure note off and cleanup remove voices from the tracking dictionary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd7c7e8e1c833385de9b058106e424