### PR TITLE
Add MPE poly-channel handling and enhance synth envelopes

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -3,14 +3,26 @@ if(MIDIClient.initialized.not) {
 };
 
 ~setupMidi = {
-    var matchDevice;
+    var matchDevice, ensureChannelState;
 
     ~midiResponders.tryPerform(\do, _.tryPerform(\free));
     ~midiResponders = List.new;
-    ~roliSineVoices.tryPerform(\do, { |synth|
-        synth.tryPerform(\free);
+    ~roliSineVoices.tryPerform(\do, { |voice|
+        if(voice.isKindOf(Synth)) {
+            voice.tryPerform(\free);
+        } {
+            voice[\synth].tryPerform(\free);
+        };
     });
     ~roliSineVoices = IdentityDictionary.new;
+    ~mpeChannelState = IdentityDictionary.new;
+    ~mpePitchBendRange = ~mpePitchBendRange ?? { 48 };
+
+    ensureChannelState = { |channel|
+        ~mpeChannelState[channel] ?? {
+            ~mpeChannelState[channel] = (pressure: 1, bend: 0);
+        };
+    };
 
     MIDIIn.disconnectAll;
     MIDIIn.connectAll;
@@ -32,17 +44,51 @@ if(MIDIClient.initialized.not) {
             var freq = note.midicps;
             var amp = velocity.linlin(1, 127, 0.02, 0.5);
             var outBus = ~directBus ?? { 0 };
+            var channelKey = channel;
+            var state = ensureChannelState.(channelKey);
+            var existing = ~roliSineVoices[channelKey];
+            var pressure = (state[\pressure] ?? { 1 }).clip(0, 1);
+            if(pressure <= 0.001) {
+                pressure = 1;
+            };
+            var bend = state[\bend] ?? { 0 };
             var synth;
+
+            if(existing.notNil) {
+                if(existing.isKindOf(Synth)) {
+                    existing.tryPerform(\set, \modAmp, 0, \gate, 0);
+                } {
+                    existing[\synth].tryPerform(\set, \modAmp, 0, \gate, 0);
+                };
+            };
+
+            state[\pressure] = pressure;
+
             synth = Synth(\percussiveSine, [
                 \freq, freq,
                 \amp, amp,
-				\gate, 1,
-                \out, outBus
+                \gate, 1,
+                \out, outBus,
+                \modAmp, pressure,
+                \bend, bend
             ]);
-            ~roliSineVoices[note] = synth;
+
+            ~roliSineVoices[channelKey] = (note: note, synth: synth);
+
             synth.onFree({
                 {
-                    ~roliSineVoices.removeAt(note);
+                    var current = ~roliSineVoices[channelKey];
+                    if(current.notNil) {
+                        if(current.isKindOf(Synth)) {
+                            if(current === synth) {
+                                ~roliSineVoices.removeAt(channelKey);
+                            };
+                        } {
+                            if(current[\synth] === synth) {
+                                ~roliSineVoices.removeAt(channelKey);
+                            };
+                        };
+                    };
                 }.defer;
             });
         };
@@ -50,28 +96,52 @@ if(MIDIClient.initialized.not) {
 
     ~midiResponders.add(MIDIFunc.polytouch({ |pressure, note, channel, src|
         if(matchDevice.(src)) {
-            var synth = ~roliSineVoices[note];
+            var channelKey = channel;
+            var state = ensureChannelState.(channelKey);
             var mod = pressure.linlin(0, 127, 0, 1).clip(0, 1);
-            if(synth.notNil) {
-                synth.tryPerform(\set, \modAmp, mod);
+            var voice = ~roliSineVoices[channelKey];
+            state[\pressure] = mod;
+            if(voice.notNil and: { voice[\note] == note }) {
+                voice[\synth].tryPerform(\set, \modAmp, mod);
             };
         };
     }));
 
     ~midiResponders.add(MIDIFunc.touch({ |pressure, channel, src|
         if(matchDevice.(src)) {
+            var channelKey = channel;
+            var state = ensureChannelState.(channelKey);
             var mod = pressure.linlin(0, 127, 0, 1).clip(0, 1);
-            ~roliSineVoices.do { |voice|
-                voice.tryPerform(\set, \modAmp, mod);
+            var voice = ~roliSineVoices[channelKey];
+            state[\pressure] = mod;
+            if(voice.notNil) {
+                voice[\synth].tryPerform(\set, \modAmp, mod);
+            };
+        };
+    }));
+
+    ~midiResponders.add(MIDIFunc.bend({ |value, channel, src|
+        if(matchDevice.(src)) {
+            var channelKey = channel;
+            var state = ensureChannelState.(channelKey);
+            var bend = value.linlin(0, 16383, -~mpePitchBendRange, ~mpePitchBendRange);
+            var voice = ~roliSineVoices[channelKey];
+            state[\bend] = bend;
+            if(voice.notNil) {
+                voice[\synth].tryPerform(\set, \bend, bend);
             };
         };
     }));
 
     ~midiResponders.add(MIDIFunc.noteOff({ |velocity, note, channel, src|
         if(matchDevice.(src)) {
-            var synth = ~roliSineVoices.removeAt(note);
-            if(synth.notNil) {
-                synth.tryPerform(\set, \modAmp, 0, \gate, 0);
+            var channelKey = channel;
+            var voice = ~roliSineVoices[channelKey];
+            if(voice.notNil) {
+                var synth = voice.isKindOf(Synth).if({ voice }, { voice[\synth] });
+                if(voice.isKindOf(Synth) or: { voice[\note] == note }) {
+                    synth.tryPerform(\set, \modAmp, 0, \gate, 0);
+                };
             };
         };
     }));
@@ -79,5 +149,7 @@ if(MIDIClient.initialized.not) {
     CmdPeriod.doOnce({
         ~midiResponders.tryPerform(\do, _.tryPerform(\free));
         ~midiResponders = nil;
+        ~mpeChannelState = nil;
+        ~roliSineVoices = nil;
     });
 };

--- a/modules/midi_synths.scd
+++ b/modules/midi_synths.scd
@@ -1,9 +1,24 @@
 // ================= Synthés pour les entrées MIDI =================
-SynthDef(\percussiveSine, { |out = 0, freq = 440, amp = 0.2, attack = 0.005, release = 2, modAmp = 1, gate=1|
-    var env = Env.perc(attack.max(0.001), release.max(0.01), 1, curve: -4);
-    var envGen = Env.adsr(0.001,2, 1, release).kr(2,gate);
-	var sigPerc = SinOsc.ar(freq) * envGen * amp * modAmp.lag(0.1);
-	var sigBody = SinOsc.ar(freq) * modAmp;
-	var sig = Mix.ar([sigPerc, sigBody]);
+SynthDef(\percussiveSine, {
+    |out = 0, freq = 440, amp = 0.2,
+    attack = 0.005, release = 2,
+    modAmp = 1, gate = 1, bend = 0,
+    attackRatio = 1, bodyRatio = 1,
+    bodyAttack = 0.02, attackLevel = 1, bodyLevel = 0.7|
+    var pressure = Lag.kr(modAmp.clip(0, 1), 0.05);
+    var baseFreq = freq * bend.midiratio;
+    var attackEnv = EnvGen.kr(
+        Env.perc(attack.max(0.001), release.max(0.01), attackLevel, curve: -4),
+        gate,
+        doneAction: 0
+    );
+    var bodyEnv = EnvGen.kr(
+        Env.asr(bodyAttack.max(0.001), 1, release.max(0.01), curve: -4),
+        gate,
+        doneAction: 2
+    );
+    var attackOsc = SinOsc.ar(baseFreq * attackRatio) * attackEnv;
+    var bodyOsc = SinOsc.ar(baseFreq * bodyRatio) * bodyEnv * bodyLevel;
+    var sig = (attackOsc + bodyOsc) * pressure * amp;
     Out.ar(out, sig ! 2);
 }).add;


### PR DESCRIPTION
## Summary
- add per-channel voice tracking so the MIDI layer can react to MPE poly pressure and pitch-bend messages
- update the percussive sine synth to keep dedicated attack/body oscillators with proper envelopes and pitch bend support

## Testing
- Not run (SuperCollider runtime not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dd8079775c833384fc0b9b7caa829f