### PR TITLE
Fix pitch bend range calculation in MIDI handler

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -125,7 +125,7 @@ if(MIDIClient.initialized.not) {
         if(matchDevice.(src)) {
             var channelKey = channel;
             var state = ensureChannelState.(channelKey);
-            var bend = value.linlin(0, 16383, -~mpePitchBendRange, ~mpePitchBendRange);
+            var bend = value.linlin(0, 16383, (~mpePitchBendRange * -1), ~mpePitchBendRange);
             var voice = ~roliSineVoices[channelKey];
             state[\bend] = bend;
             if(voice.notNil) {


### PR DESCRIPTION
## Summary
- replace invalid unary negation syntax for SuperCollider environment variables
- ensure MIDI pitch bend range mapping uses a valid negative range value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd8347bab883339068777a08c75d5f