### PR TITLE
Handle MIDI note-off messages and add ADSR to sine synth

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -3,13 +3,22 @@ if(MIDIClient.initialized.not) {
 };
 
 ~setupMidi = {
-    var matchDevice;
+    var matchDevice, makeKey;
 
     ~midiResponders.tryPerform(\do, _.tryPerform(\free));
     ~midiResponders = List.new;
 
+    ~activeMidiSynths.tryPerform(\valuesDo, { |synth|
+        synth.tryPerform(\set, \gate, 0);
+    });
+    ~activeMidiSynths = IdentityDictionary.new;
+
     MIDIIn.disconnectAll;
     MIDIIn.connectAll;
+
+    makeKey = { |src, channel, note|
+        "%:%:%".format(src, channel, note);
+    };
 
     matchDevice = { |src|
         var source;
@@ -25,19 +34,38 @@ if(MIDIClient.initialized.not) {
 
     ~midiResponders.add(MIDIFunc.noteOn({ |velocity, note, channel, src|
         if(matchDevice.(src)) {
-            var freq = note.midicps;
-            var amp = velocity.linlin(1, 127, 0.02, 0.5);
-            var outBus = ~directBus ?? { 0 };
-            Synth(\percussiveSine, [
-                \freq, freq,
-                \amp, amp,
-                \out, outBus
-            ]);
+            var key = makeKey.(src, channel, note);
+            if(velocity <= 0) {
+                var synth = ~activeMidiSynths.removeAt(key);
+                synth.tryPerform(\set, \gate, 0);
+            } {
+                var freq = note.midicps;
+                var amp = velocity.linlin(1, 127, 0.02, 0.5);
+                var outBus = ~directBus ?? { 0 };
+                var synth = Synth(\percussiveSine, [
+                    \freq, freq,
+                    \amp, amp,
+                    \out, outBus
+                ]);
+                ~activeMidiSynths[key] = synth;
+            };
+        };
+    }));
+
+    ~midiResponders.add(MIDIFunc.noteOff({ |velocity, note, channel, src|
+        if(matchDevice.(src)) {
+            var key = makeKey.(src, channel, note);
+            var synth = ~activeMidiSynths.removeAt(key);
+            synth.tryPerform(\set, \gate, 0);
         };
     }));
 
     CmdPeriod.doOnce({
         ~midiResponders.tryPerform(\do, _.tryPerform(\free));
         ~midiResponders = nil;
+        ~activeMidiSynths.tryPerform(\valuesDo, { |synth|
+            synth.tryPerform(\set, \gate, 0);
+        });
+        ~activeMidiSynths = nil;
     });
 };

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -6,9 +6,15 @@ SynthDef(\outputLimiter, { |input = 0, out = 0|
 }).add;
 
 // ================= Bus direct et synthé percussif =================
-SynthDef(\percussiveSine, { |out = 0, freq = 440, amp = 0.2, attack = 0.005, release = 0.35|
-    var env = Env.perc(attack.max(0.001), release.max(0.01), 1, curve: -4);
-    var envGen = EnvGen.kr(env, doneAction: 2);
+SynthDef(\percussiveSine, { |out = 0, freq = 440, amp = 0.2, attack = 0.01, decay = 0.2, sustain = 0.7, release = 0.4, gate = 1|
+    var env = Env.adsr(
+        attack.max(0.001),
+        decay.max(0.001),
+        sustain.clip(0, 1),
+        release.max(0.01),
+        curve: -4
+    );
+    var envGen = EnvGen.kr(env, gate, doneAction: 2);
     var sig = SinOsc.ar(freq) * envGen * amp;
     Out.ar(out, sig ! 2);
 }).add;


### PR DESCRIPTION
## Summary
- track active MIDI-driven synths so note-on messages can retrigger them and note-off (or velocity-zero) messages release them
- add a dedicated MIDI note-off responder and clean up active synths when reinitializing or stopping
- replace the percussive sine synth envelope with an ADSR-controlled version supporting gated releases

## Testing
- not run (SuperCollider environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd87f769f083338c90628b5a99f37a