### PR TITLE
Handle overlapping MIDI note-on events

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -42,6 +42,8 @@ if(MIDIClient.initialized.not) {
                 var freq = note.midicps;
                 var amp = velocity.linlin(1, 127, 0.02, 0.5);
                 var outBus = ~directBus ?? { 0 };
+                var existingSynth = ~activeMidiSynths.removeAt(key);
+                existingSynth.tryPerform(\set, \gate, 0);
                 var synth = Synth(\percussiveSine, [
                     \freq, freq,
                     \amp, amp,


### PR DESCRIPTION
## Summary
- stop any previous synth for a MIDI note before creating a new one

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd8963f888833396d73a712803837b