### PR TITLE
Fix MIDI note-on variable declarations

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -39,12 +39,13 @@ if(MIDIClient.initialized.not) {
                 var synth = ~activeMidiSynths.removeAt(key);
                 synth.tryPerform(\set, \gate, 0);
             } {
-                var freq = note.midicps;
-                var amp = velocity.linlin(1, 127, 0.02, 0.5);
-                var outBus = ~directBus ?? { 0 };
-                var existingSynth = ~activeMidiSynths.removeAt(key);
+                var freq, amp, outBus, existingSynth, synth;
+                freq = note.midicps;
+                amp = velocity.linlin(1, 127, 0.02, 0.5);
+                outBus = ~directBus ?? { 0 };
+                existingSynth = ~activeMidiSynths.removeAt(key);
                 existingSynth.tryPerform(\set, \gate, 0);
-                var synth = Synth(\percussiveSine, [
+                synth = Synth(\percussiveSine, [
                     \freq, freq,
                     \amp, amp,
                     \out, outBus


### PR DESCRIPTION
## Summary
- declare MIDI note-on handler variables at the start of the block to satisfy SuperCollider syntax rules
- prevent syntax errors when instantiating the percussive synth and ensure note-off cleanup runs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd8a5fd2608333af201dac3854371f