### PR TITLE
Add verbose MIDI note logging to debug stuck notes

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -33,10 +33,15 @@ if(MIDIClient.initialized.not) {
     };
 
     ~midiResponders.add(MIDIFunc.noteOn({ |velocity, note, channel, src|
-        if(matchDevice.(src)) {
+        var deviceMatches = matchDevice.(src);
+        ("[MIDI] noteOn src:% channel:% note:% velocity:% match:%"
+            .format(src, channel, note, velocity, deviceMatches)).postln;
+        if(deviceMatches) {
             var key = makeKey.(src, channel, note);
             if(velocity <= 0) {
                 var synth = ~activeMidiSynths.removeAt(key);
+                ("[MIDI] noteOn treated as noteOff key:% synth:%"
+                    .format(key, synth)).postln;
                 synth.tryPerform(\set, \gate, 0);
             } {
                 var freq, amp, outBus, existingSynth, synth;
@@ -44,22 +49,37 @@ if(MIDIClient.initialized.not) {
                 amp = velocity.linlin(1, 127, 0.02, 0.5);
                 outBus = ~directBus ?? { 0 };
                 existingSynth = ~activeMidiSynths.removeAt(key);
+                ("[MIDI] stopping existing synth for key:% -> %"
+                    .format(key, existingSynth)).postln;
                 existingSynth.tryPerform(\set, \gate, 0);
                 synth = Synth(\percussiveSine, [
                     \freq, freq,
                     \amp, amp,
                     \out, outBus
                 ]);
+                ("[MIDI] started synth % for key:% freq:% amp:% out:%"
+                    .format(synth, key, freq, amp, outBus)).postln;
                 ~activeMidiSynths[key] = synth;
             };
+        } {
+            ("[MIDI] noteOn ignored - device mismatch for src:%"
+                .format(src)).postln;
         };
     }));
 
     ~midiResponders.add(MIDIFunc.noteOff({ |velocity, note, channel, src|
-        if(matchDevice.(src)) {
+        var deviceMatches = matchDevice.(src);
+        ("[MIDI] noteOff src:% channel:% note:% velocity:% match:%"
+            .format(src, channel, note, velocity, deviceMatches)).postln;
+        if(deviceMatches) {
             var key = makeKey.(src, channel, note);
             var synth = ~activeMidiSynths.removeAt(key);
+            ("[MIDI] noteOff releasing synth for key:% -> %"
+                .format(key, synth)).postln;
             synth.tryPerform(\set, \gate, 0);
+        } {
+            ("[MIDI] noteOff ignored - device mismatch for src:%"
+                .format(src)).postln;
         };
     }));
 


### PR DESCRIPTION
## Summary
- add detailed logging to MIDI note on/off handlers to trace device matching and synth lifecycle
- log note-on velocity zero as a note-off scenario and highlight ignored events due to device mismatch

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8b2e67988333a7ddeac1db867a2e