### PR TITLE
Fix stuck MIDI notes caused by dictionary identity comparison

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -11,7 +11,7 @@ if(MIDIClient.initialized.not) {
     ~activeMidiSynths.tryPerform(\valuesDo, { |synth|
         synth.tryPerform(\set, \gate, 0);
     });
-    ~activeMidiSynths = IdentityDictionary.new;
+    ~activeMidiSynths = Dictionary.new;
 
     MIDIIn.disconnectAll;
     MIDIIn.connectAll;


### PR DESCRIPTION
## Summary
- replace the IdentityDictionary used for tracking active MIDI synths with a regular Dictionary so identical keys can be found on noteOff events
- ensures noteOff messages properly close the corresponding synth and avoid indefinitely sustained notes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd8bccb0d08333ace58f0758da8a63