### PR TITLE
Refactor MIDI synth handling and add Braids voice

### DIFF
--- a/main.scd
+++ b/main.scd
@@ -12,6 +12,7 @@ s.options.numInputBusChannels = 8;
 // ======================
 ~bootMixTable = {
     ("modules/synths.scd").loadRelative;
+    ("modules/midi_synths.scd").loadRelative;
     ("modules/midi.scd").loadRelative;
     ("modules/ui.scd").loadRelative;
 

--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -3,7 +3,7 @@ if(MIDIClient.initialized.not) {
 };
 
 ~setupMidi = {
-    var matchDevice, makeKey;
+    var matchDevice, makeKey, spawnMidiSynth;
 
     ~midiResponders.tryPerform(\do, _.tryPerform(\free));
     ~midiResponders = List.new;
@@ -18,6 +18,21 @@ if(MIDIClient.initialized.not) {
 
     makeKey = { |src, channel, note|
         "%:%:%".format(src, channel, note);
+    };
+
+    spawnMidiSynth = { |freq, amp, outBus, velocity = 0|
+        var synthKey, registry, entry, argBuilder, args;
+
+        registry = ~midiSynthRegistry ?? { Dictionary.new };
+        synthKey = ~currentMidiSynth.tryPerform(\value) ?? {
+            (~currentMidiSynth ? \percussiveSine)
+        };
+        entry = registry[synthKey];
+        argBuilder = entry.tryPerform(\at, \makeArgs);
+        args = argBuilder.tryPerform(\value, freq, amp, outBus, velocity) ?? {
+            [\freq, freq, \amp, amp, \out, outBus]
+        };
+        Synth(synthKey, args);
     };
 
     matchDevice = { |src|
@@ -52,11 +67,7 @@ if(MIDIClient.initialized.not) {
                 ("[MIDI] stopping existing synth for key:% -> %"
                     .format(key, existingSynth)).postln;
                 existingSynth.tryPerform(\set, \gate, 0);
-                synth = Synth(\percussiveSine, [
-                    \freq, freq,
-                    \amp, amp,
-                    \out, outBus
-                ]);
+                synth = spawnMidiSynth.(freq, amp, outBus, velocity);
                 ("[MIDI] started synth % for key:% freq:% amp:% out:%"
                     .format(synth, key, freq, amp, outBus)).postln;
                 ~activeMidiSynths[key] = synth;

--- a/modules/midi_synths.scd
+++ b/modules/midi_synths.scd
@@ -1,0 +1,95 @@
+// ================= Synthés contrôlés par MIDI =================
+
+// Registre global pour les synthés accessibles via le responder MIDI.
+~midiSynthRegistry = ~midiSynthRegistry ?? { Dictionary.new };
+
+// ----------------- Sine percussif -----------------
+SynthDef(\percussiveSine, {
+    |out = 0, freq = 440, amp = 0.2, attack = 0.01, decay = 0.2, sustain = 0.7, release = 0.4, gate = 1|
+    var env = Env.adsr(
+        attack.max(0.001),
+        decay.max(0.001),
+        sustain.clip(0, 1),
+        release.max(0.01),
+        curve: -4
+    );
+    var envGen = EnvGen.kr(env, gate, doneAction: 2);
+    var sig = SinOsc.ar(freq) * envGen * amp;
+    Out.ar(out, sig ! 2);
+}).add;
+
+~midiSynthRegistry[\percussiveSine] = (
+    label: "Sine percussif",
+    makeArgs: { |freq, amp, out, velocity = 0|
+        [
+            \freq, freq,
+            \amp, amp,
+            \out, out,
+            \gate, 1
+        ]
+    }
+);
+
+// ----------------- Mutable Instruments Braids -----------------
+SynthDef(\miBraidsVoice, {
+    |out = 0, gate = 1, freq = 440, amp = 0.2,
+    attack = 0.01, decay = 0.2, sustain = 0.6, release = 0.4,
+    timbre = 0.5, color = 0.5, model = 0,
+    resamp = 2, decim = 0, bits = 0, ws = 0,
+    pitchOffset = 0, rootNote = 0, fm = 0, envMod = 0,
+    manualTrig = 0, level = 0.8, eocAmp = 0|
+    var env = Env.adsr(
+        attack.max(0.001),
+        decay.max(0.001),
+        sustain.clip(0, 1),
+        release.max(0.01),
+        curve: -4
+    );
+    var envGen = EnvGen.kr(env, gate, doneAction: 2);
+    var gateTrig = Trig1.kr(HPZ1.kr(gate).max(0), 0.001);
+    var pitch = freq.cpsmidi + pitchOffset;
+    var braids = MiBraids.ar(
+        pitch: pitch,
+        timbre: timbre,
+        color: color,
+        model: model,
+        trig: manualTrig + gateTrig,
+        resamp: resamp,
+        decim: decim,
+        bits: bits,
+        ws: ws,
+        root: rootNote,
+        fm: fm,
+        env: envMod,
+        level: level,
+        eoc: eocAmp
+    );
+    var sig = braids.asArray;
+    sig = (sig.size >= 2).if({ sig.copyRange(0, 1) }, { sig[0] ! 2 });
+    sig = sig * envGen * amp;
+    Out.ar(out, sig);
+}).add;
+
+~midiSynthRegistry[\miBraidsVoice] = (
+    label: "Mutable Instruments Braids",
+    makeArgs: { |freq, amp, out, velocity = 0|
+        [
+            \freq, freq,
+            \amp, amp,
+            \out, out,
+            \gate, 1,
+            \manualTrig, 0
+        ]
+    }
+);
+
+~currentMidiSynth = ~currentMidiSynth ?? { \percussiveSine };
+
+~setCurrentMidiSynth = { |synthKey|
+    var registry = ~midiSynthRegistry ?? { Dictionary.new };
+    if(registry.includesKey(synthKey)) {
+        ~currentMidiSynth = synthKey;
+    } {
+        ("[MIDI] Synth inconnue %".format(synthKey)).warn;
+    };
+};

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -5,21 +5,7 @@ SynthDef(\outputLimiter, { |input = 0, out = 0|
     Out.ar(out, limited.tanh);
 }).add;
 
-// ================= Bus direct et synthé percussif =================
-SynthDef(\percussiveSine, { |out = 0, freq = 440, amp = 0.2, attack = 0.01, decay = 0.2, sustain = 0.7, release = 0.4, gate = 1|
-    var env = Env.adsr(
-        attack.max(0.001),
-        decay.max(0.001),
-        sustain.clip(0, 1),
-        release.max(0.01),
-        curve: -4
-    );
-    var envGen = EnvGen.kr(env, gate, doneAction: 2);
-    var sig = SinOsc.ar(freq) * envGen * amp;
-    Out.ar(out, sig ! 2);
-}).add;
-
-// ================= Mixage et gestion des bus =================
+// ================= Bus direct et mixage =================
 
 // Définitions des tranches d'entrée : 1 (mono), 3/4, 5/6, 7/8
 ~mixInputs = [


### PR DESCRIPTION
## Summary
- move MIDI-controlled synth definitions into a dedicated module
- add a Mutable Instruments Braids-based SynthDef with full parameter control
- update MIDI responder to use a registry-driven synth spawner and load the new module

## Testing
- not run (SuperCollider environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd8cc6653c8333a79a7717e718b937