### PR TITLE
Handle missing MiBraids synth with fallback

### DIFF
--- a/modules/midi_synths.scd
+++ b/modules/midi_synths.scd
@@ -31,44 +31,66 @@ SynthDef(\percussiveSine, {
 );
 
 // ----------------- Mutable Instruments Braids -----------------
-SynthDef(\miBraidsVoice, {
-    |out = 0, gate = 1, freq = 440, amp = 0.2,
-    attack = 0.01, decay = 0.2, sustain = 0.6, release = 0.4,
-    timbre = 0.5, color = 0.5, model = 0,
-    resamp = 2, decim = 0, bits = 0, ws = 0,
-    pitchOffset = 0, rootNote = 0, fm = 0, envMod = 0,
-    manualTrig = 0, level = 0.8, eocAmp = 0|
-    var env = Env.adsr(
-        attack.max(0.001),
-        decay.max(0.001),
-        sustain.clip(0, 1),
-        release.max(0.01),
-        curve: -4
-    );
-    var envGen = EnvGen.kr(env, gate, doneAction: 2);
-    var gateTrig = Trig1.kr(HPZ1.kr(gate).max(0), 0.001);
-    var pitch = freq.cpsmidi + pitchOffset;
-    var braids = MiBraids.ar(
-        pitch: pitch,
-        timbre: timbre,
-        color: color,
-        model: model,
-        trig: manualTrig + gateTrig,
-        resamp: resamp,
-        decim: decim,
-        bits: bits,
-        ws: ws,
-        root: rootNote,
-        fm: fm,
-        env: envMod,
-        level: level,
-        eoc: eocAmp
-    );
-    var sig = braids.asArray;
-    sig = (sig.size >= 2).if({ sig.copyRange(0, 1) }, { sig[0] ! 2 });
-    sig = sig * envGen * amp;
-    Out.ar(out, sig);
-}).add;
+var miBraidsClass = Class.find(\MiBraids);
+
+if(miBraidsClass.notNil) {
+    SynthDef(\miBraidsVoice, {
+        |out = 0, gate = 1, freq = 440, amp = 0.2,
+        attack = 0.01, decay = 0.2, sustain = 0.6, release = 0.4,
+        timbre = 0.5, color = 0.5, model = 0,
+        resamp = 2, decim = 0, bits = 0, ws = 0,
+        pitchOffset = 0, rootNote = 0, fm = 0, envMod = 0,
+        manualTrig = 0, level = 0.8, eocAmp = 0|
+        var env = Env.adsr(
+            attack.max(0.001),
+            decay.max(0.001),
+            sustain.clip(0, 1),
+            release.max(0.01),
+            curve: -4
+        );
+        var envGen = EnvGen.kr(env, gate, doneAction: 2);
+        var gateTrig = Trig1.kr(HPZ1.kr(gate).max(0), 0.001);
+        var pitch = freq.cpsmidi + pitchOffset;
+        var braids = miBraidsClass.ar(
+            pitch: pitch,
+            timbre: timbre,
+            color: color,
+            model: model,
+            trig: manualTrig + gateTrig,
+            resamp: resamp,
+            decim: decim,
+            bits: bits,
+            ws: ws,
+            root: rootNote,
+            fm: fm,
+            env: envMod,
+            level: level,
+            eoc: eocAmp
+        );
+        var sig = braids.asArray;
+        sig = (sig.size >= 2).if({ sig.copyRange(0, 1) }, { sig[0] ! 2 });
+        sig = sig * envGen * amp;
+        Out.ar(out, sig);
+    }).add;
+} {
+    "[MIDI] MiBraids introuvable - chargement d'un synthé de secours.".warn;
+    SynthDef(\miBraidsVoice, {
+        |out = 0, gate = 1, freq = 440, amp = 0.2,
+        attack = 0.01, decay = 0.2, sustain = 0.6, release = 0.4,
+        timbre = 0.5, color = 0.5, model = 0|
+        var env = Env.adsr(
+            attack.max(0.001),
+            decay.max(0.001),
+            sustain.clip(0, 1),
+            release.max(0.01),
+            curve: -4
+        );
+        var envGen = EnvGen.kr(env, gate, doneAction: 2);
+        var sig = VarSaw.ar(freq, width: timbre.linlin(0, 1, 0.2, 0.8));
+        sig = (sig * envGen * amp).dup;
+        Out.ar(out, sig);
+    }).add;
+};
 
 ~midiSynthRegistry[\miBraidsVoice] = (
     label: "Mutable Instruments Braids",


### PR DESCRIPTION
## Summary
- check for the MiBraids UGen before registering the miBraidsVoice SynthDef
- load the original Braids voice when the plugin exists and warn when it does not
- provide a simple VarSaw-based fallback SynthDef so MIDI playback continues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd911a10dc8333acd378c6cdc3fbf7