### PR TITLE
Add membrane and Karplus-Strong MIDI synths with CC modulation

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -8,10 +8,12 @@ if(MIDIClient.initialized.not) {
     ~midiResponders.tryPerform(\do, _.tryPerform(\free));
     ~midiResponders = List.new;
 
-    ~activeMidiSynths.tryPerform(\valuesDo, { |synth|
+    ~activeMidiSynths.tryPerform(\valuesDo, { |entry|
+        var synth = entry.tryPerform(\at, \synth) ?? { entry };
         synth.tryPerform(\set, \gate, 0);
     });
     ~activeMidiSynths = Dictionary.new;
+    ~midiCCValues = IdentityDictionary.new;
 
     MIDIIn.disconnectAll;
     MIDIIn.connectAll;
@@ -39,27 +41,52 @@ if(MIDIClient.initialized.not) {
         if(deviceMatches) {
             var key = makeKey.(src, channel, note);
             if(velocity <= 0) {
-                var synth = ~activeMidiSynths.removeAt(key);
+                var entry = ~activeMidiSynths.removeAt(key);
+                var synth = entry.tryPerform(\at, \synth) ?? { entry };
                 ("[MIDI] noteOn treated as noteOff key:% synth:%"
                     .format(key, synth)).postln;
                 synth.tryPerform(\set, \gate, 0);
             } {
-                var freq, amp, outBus, existingSynth, synth;
+                var freq, amp, outBus, existingEntry, existingSynth, synth, synthKey, config;
+                var ccValue, args, channelCCValue, ccParam, ccDefault, ccMap, extraArgs;
                 freq = note.midicps;
                 amp = velocity.linlin(1, 127, 0.02, 0.5);
                 outBus = ~directBus ?? { 0 };
-                existingSynth = ~activeMidiSynths.removeAt(key);
+                existingEntry = ~activeMidiSynths.removeAt(key);
+                existingSynth = existingEntry.tryPerform(\at, \synth) ?? { existingEntry };
                 ("[MIDI] stopping existing synth for key:% -> %"
                     .format(key, existingSynth)).postln;
                 existingSynth.tryPerform(\set, \gate, 0);
-                synth = Synth(\percussiveSine, [
+                synthKey = ~midiSynthRouting[channel] ?? { ~defaultMidiSynth };
+                if(synthKey.respondsTo(\asSymbol)) {
+                    synthKey = synthKey.asSymbol;
+                } {
+                    synthKey = ~defaultMidiSynth;
+                };
+                config = ~midiSynthConfigs[synthKey] ?? { IdentityDictionary.new };
+                ccParam = config[\ccParam];
+                ccMap = config[\ccMap] ?? { |val| val };
+                ccDefault = config[\ccDefault] ?? { 64 };
+                channelCCValue = ~midiCCValues[channel];
+                if(channelCCValue.isNil) {
+                    channelCCValue = ccDefault;
+                    ~midiCCValues[channel] = channelCCValue;
+                };
+                ccValue = ccMap.(channelCCValue);
+                extraArgs = config[\extraArgs].tryPerform(\value, freq, velocity, amp) ?? { [] };
+                args = [
                     \freq, freq,
                     \amp, amp,
                     \out, outBus
-                ]);
-                ("[MIDI] started synth % for key:% freq:% amp:% out:%"
-                    .format(synth, key, freq, amp, outBus)).postln;
-                ~activeMidiSynths[key] = synth;
+                ];
+                if(ccParam.notNil) {
+                    args = args ++ [ccParam, ccValue];
+                };
+                args = args ++ extraArgs;
+                synth = Synth(synthKey, args);
+                ("[MIDI] started % synth % for key:% freq:% amp:% out:% ccValue:%"
+                    .format(synthKey, synth, key, freq, amp, outBus, ccValue)).postln;
+                ~activeMidiSynths[key] = (synth: synth, type: synthKey, channel: channel);
             };
         } {
             ("[MIDI] noteOn ignored - device mismatch for src:%"
@@ -73,7 +100,8 @@ if(MIDIClient.initialized.not) {
             .format(src, channel, note, velocity, deviceMatches)).postln;
         if(deviceMatches) {
             var key = makeKey.(src, channel, note);
-            var synth = ~activeMidiSynths.removeAt(key);
+            var entry = ~activeMidiSynths.removeAt(key);
+            var synth = entry.tryPerform(\at, \synth) ?? { entry };
             ("[MIDI] noteOff releasing synth for key:% -> %"
                 .format(key, synth)).postln;
             synth.tryPerform(\set, \gate, 0);
@@ -83,12 +111,37 @@ if(MIDIClient.initialized.not) {
         };
     }));
 
+    ~midiResponders.add(MIDIFunc.cc({ |value, ccNum, channel, src|
+        var deviceMatches = matchDevice.(src);
+        ("[MIDI] cc src:% channel:% cc:% value:% match:%"
+            .format(src, channel, ccNum, value, deviceMatches)).postln;
+        if(deviceMatches) {
+            ~midiCCValues[channel] = value;
+            ~activeMidiSynths.tryPerform(\valuesDo, { |entry|
+                var synth = entry.tryPerform(\at, \synth);
+                var type = entry.tryPerform(\at, \type);
+                var entryChannel = entry.tryPerform(\at, \channel);
+                var config, ccParam, ccMap;
+                if((synth.notNil) and: { entryChannel == channel }) {
+                    config = ~midiSynthConfigs[type] ?? { IdentityDictionary.new };
+                    ccParam = config[\ccParam];
+                    ccMap = config[\ccMap] ?? { |val| val };
+                    if(ccParam.notNil) {
+                        synth.tryPerform(\set, ccParam, ccMap.(value));
+                    };
+                };
+            });
+        };
+    }, 74));
+
     CmdPeriod.doOnce({
         ~midiResponders.tryPerform(\do, _.tryPerform(\free));
         ~midiResponders = nil;
-        ~activeMidiSynths.tryPerform(\valuesDo, { |synth|
+        ~activeMidiSynths.tryPerform(\valuesDo, { |entry|
+            var synth = entry.tryPerform(\at, \synth) ?? { entry };
             synth.tryPerform(\set, \gate, 0);
         });
         ~activeMidiSynths = nil;
+        ~midiCCValues = nil;
     });
 };

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -1,0 +1,73 @@
+// ================= Synthés MIDI =================
+
+// Définition d'un sine percussif avec contrôle de brillance
+SynthDef(\percussiveSine, {
+    |out = 0, freq = 440, amp = 0.2, attack = 0.01, decay = 0.2, sustain = 0.7,
+    release = 0.4, gate = 1, brightHz = 5000|
+    var env = Env.adsr(
+        attack.max(0.001),
+        decay.max(0.001),
+        sustain.clip(0, 1),
+        release.max(0.01),
+        curve: -4
+    );
+    var envGen = EnvGen.kr(env, gate, doneAction: 2);
+    var sig = SinOsc.ar(freq) * envGen * amp;
+    sig = LPF.ar(sig, brightHz.clip(200, 12000));
+    Out.ar(out, sig ! 2);
+}).add;
+
+// Définition d'un synthé basé sur MembraneHexagon
+SynthDef(\membraneHit, {
+    |out = 0, freq = 110, amp = 0.2, gate = 1, tension = 0.6|
+    var ampEnv = EnvGen.kr(Env.asr(0.005, 1, 1.5, curve: -4), gate, doneAction: 2);
+    var exciteEnv = EnvGen.kr(Env.perc(0.001, 0.08, 1, curve: -6), gate);
+    var excitation = PinkNoise.ar(exciteEnv);
+    var membrane = MembraneHexagon.ar(excitation, tension.clip(0.05, 0.99));
+    var resonated = BPF.ar(membrane, freq.clip(40, 4000), 0.2);
+    Out.ar(out, (resonated * ampEnv * amp).tanh ! 2);
+}).add;
+
+// Définition d'un synthé Karplus-Strong (Pluck)
+SynthDef(\karplusString, {
+    |out = 0, freq = 220, amp = 0.2, gate = 1, trig = 1, decayTime = 3, damping = 0.5|
+    var env = EnvGen.kr(Env.asr(0.005, 1, decayTime, curve: -4), gate, doneAction: 2);
+    var excitation = WhiteNoise.ar(amp * 0.5);
+    var sig = Pluck.ar(
+        excitation,
+        trig,
+        (1 / 20),
+        freq.reciprocal,
+        decayTime.max(0.1),
+        damping.clip(0.05, 0.99)
+    );
+    Out.ar(out, (sig * env).dup);
+}).add;
+
+// Configuration des synthés MIDI disponibles et des paramètres modulables par CC
+~midiSynthConfigs = IdentityDictionary.newFrom([
+    \percussiveSine, (
+        ccParam: \brightHz,
+        ccDefault: 74, // valeur de CC "brightness" par défaut
+        ccMap: { |value| value.linexp(0, 127, 400, 12000) },
+        extraArgs: { [] }
+    ),
+    \membraneHit, (
+        ccParam: \tension,
+        ccDefault: 64,
+        ccMap: { |value| value.linlin(0, 127, 0.1, 0.95) },
+        extraArgs: { [] }
+    ),
+    \karplusString, (
+        ccParam: \damping,
+        ccDefault: 64,
+        ccMap: { |value| value.linlin(0, 127, 0.1, 0.95) },
+        extraArgs: { [\trig, 1] }
+    )
+]);
+
+~defaultMidiSynth = \percussiveSine;
+~midiSynthRouting = IdentityDictionary.new;
+~midiSynthRouting[0] = \percussiveSine;
+~midiSynthRouting[1] = \membraneHit;
+~midiSynthRouting[2] = \karplusString;

--- a/modules/voicer_midi.scd
+++ b/modules/voicer_midi.scd
@@ -5,20 +5,6 @@ SynthDef(\outputLimiter, { |input = 0, out = 0|
     Out.ar(out, limited.tanh);
 }).add;
 
-// ================= Bus direct et synthé percussif =================
-SynthDef(\percussiveSine, { |out = 0, freq = 440, amp = 0.2, attack = 0.01, decay = 0.2, sustain = 0.7, release = 0.4, gate = 1|
-    var env = Env.adsr(
-        attack.max(0.001),
-        decay.max(0.001),
-        sustain.clip(0, 1),
-        release.max(0.01),
-        curve: -4
-    );
-    var envGen = EnvGen.kr(env, gate, doneAction: 2);
-    var sig = SinOsc.ar(freq) * envGen * amp;
-    Out.ar(out, sig ! 2);
-}).add;
-
 // ================= Mixage et gestion des bus =================
 
 // Définitions des tranches d'entrée : 1 (mono), 3/4, 5/6, 7/8


### PR DESCRIPTION
## Summary
- add a dedicated `modules/synths.scd` file defining the MIDI synths and their CC mappings
- integrate new membrane and Karplus-Strong synth options with per-channel routing and CC74 modulation
- update MIDI responders to store synth metadata and react to CC74 messages while removing the legacy definition

## Testing
- not run (SuperCollider environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd92e39eac83338a85487a5e4504f2