### PR TITLE
Add MIDI synth selection helpers and tame membrane burst

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -2,6 +2,50 @@ if(MIDIClient.initialized.not) {
     MIDIClient.init;
 };
 
+~normalizeSynthKey = { |key|
+    if(key.isNil) { ^nil };
+    if(key.respondsTo(\asSymbol)) { ^key.asSymbol };
+    (key.isKindOf(Symbol)).if({ key }, { nil });
+};
+
+~setMidiSynthForKey = { |key, synthKey|
+    var normalizedKey = ~normalizeSynthKey.(key);
+    var normalizedSynth = ~normalizeSynthKey.(synthKey);
+    if(normalizedKey.isNil) {
+        ("[MIDI] Impossible d'enregistrer le synthé : clef invalide %".format(key)).warn;
+        ^nil;
+    };
+    if(normalizedSynth.isNil or: { ~midiSynthConfigs.includesKey(normalizedSynth).not }) {
+        ("[MIDI] Synthé inconnu %".format(synthKey)).warn;
+        ^nil;
+    };
+    ~midiSynthRouting[normalizedKey] = normalizedSynth;
+    if(normalizedKey == \default) {
+        ~currentMidiSynthKey = normalizedSynth;
+    };
+    ("[MIDI] Clef % associée au synthé %".format(normalizedKey, normalizedSynth)).postln;
+};
+
+~setActiveMidiSynth = { |key|
+    var normalizedKey = ~normalizeSynthKey.(key);
+    var resolvedSynth;
+    if(normalizedKey.isNil) {
+        ("[MIDI] Clef invalide %".format(key)).warn;
+        ^nil;
+    };
+    resolvedSynth = ~midiSynthConfigs.includesKey(normalizedKey).if({ normalizedKey }, {
+        ~midiSynthRouting[normalizedKey]
+    });
+    if(resolvedSynth.isNil) {
+        ("[MIDI] Aucun synthé trouvé pour la clef %".format(normalizedKey)).warn;
+        ^nil;
+    };
+    resolvedSynth = resolvedSynth.asSymbol;
+    ~currentMidiSynthKey = resolvedSynth;
+    ~midiSynthRouting[\default] = resolvedSynth;
+    ("[MIDI] Synthé MIDI actif -> %".format(resolvedSynth)).postln;
+};
+
 ~setupMidi = {
     var matchDevice, makeKey;
 
@@ -34,6 +78,8 @@ if(MIDIClient.initialized.not) {
         }
     };
 
+    ~currentMidiSynthKey = ~currentMidiSynthKey ?? { ~midiSynthRouting[\default] ?? { ~defaultMidiSynth } };
+
     ~midiResponders.add(MIDIFunc.noteOn({ |velocity, note, channel, src|
         var deviceMatches = matchDevice.(src);
         ("[MIDI] noteOn src:% channel:% note:% velocity:% match:%"
@@ -57,7 +103,7 @@ if(MIDIClient.initialized.not) {
                 ("[MIDI] stopping existing synth for key:% -> %"
                     .format(key, existingSynth)).postln;
                 existingSynth.tryPerform(\set, \gate, 0);
-                synthKey = ~midiSynthRouting[channel] ?? { ~defaultMidiSynth };
+                synthKey = ~midiSynthRouting[channel] ?? { ~currentMidiSynthKey ?? { ~defaultMidiSynth } };
                 if(synthKey.respondsTo(\asSymbol)) {
                     synthKey = synthKey.asSymbol;
                 } {

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -20,11 +20,12 @@ SynthDef(\percussiveSine, {
 // Définition d'un synthé basé sur MembraneHexagon
 SynthDef(\membraneHit, {
     |out = 0, freq = 110, amp = 0.2, gate = 1, tension = 0.6|
-    var ampEnv = EnvGen.kr(Env.asr(0.005, 1, 1.5, curve: -4), gate, doneAction: 2);
+    var ampEnv = EnvGen.kr(Env.asr(0.005, 1, 1.0, curve: -4), gate, doneAction: 2);
     var exciteEnv = EnvGen.kr(Env.perc(0.001, 0.08, 1, curve: -6), gate);
-    var excitation = PinkNoise.ar(exciteEnv);
-    var membrane = MembraneHexagon.ar(excitation, tension.clip(0.05, 0.99));
-    var resonated = BPF.ar(membrane, freq.clip(40, 4000), 0.2);
+    var excitation = PinkNoise.ar(exciteEnv) * 0.35;
+    var membrane = MembraneHexagon.ar(excitation, tension.clip(0.05, 0.99), loss: 0.9995);
+    var resonated = BPF.ar(LeakDC.ar(membrane), freq.clip(40, 4000), 0.2);
+    resonated = Limiter.ar(resonated, 0.9, 0.02);
     Out.ar(out, (resonated * ampEnv * amp).tanh ! 2);
 }).add;
 
@@ -68,6 +69,9 @@ SynthDef(\karplusString, {
 
 ~defaultMidiSynth = \percussiveSine;
 ~midiSynthRouting = IdentityDictionary.new;
+~midiSynthRouting[\default] = ~defaultMidiSynth;
 ~midiSynthRouting[0] = \percussiveSine;
 ~midiSynthRouting[1] = \membraneHit;
 ~midiSynthRouting[2] = \karplusString;
+
+~currentMidiSynthKey = ~defaultMidiSynth;


### PR DESCRIPTION
## Summary
- add helpers to register MIDI synths by key and select the active synth without editing channel routing
- default to the selected key when no explicit MIDI channel mapping exists
- tame the membrane-based synth by reducing the excitation energy and filtering/limiting its output

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd9719e06c833390074d14eec4e34a