### PR TITLE
Simplify MIDI synth selection

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -15,36 +15,34 @@ if(MIDIClient.initialized.not) {
         ("[MIDI] Impossible d'enregistrer le synthé : clef invalide %".format(key)).warn;
         ^nil;
     };
-    if(normalizedSynth.isNil or: { ~midiSynthConfigs.includesKey(normalizedSynth).not }) {
+    if(normalizedSynth.isNil or: { ~midiSynthLibrary.includesKey(normalizedSynth).not }) {
         ("[MIDI] Synthé inconnu %".format(synthKey)).warn;
         ^nil;
     };
-    ~midiSynthRouting[normalizedKey] = normalizedSynth;
     if(normalizedKey == \default) {
-        ~currentMidiSynthKey = normalizedSynth;
+        ^~setCurrentMidiSynth.(normalizedSynth);
+    } {
+        ~midiSynthRouting[normalizedKey] = normalizedSynth;
+        ("[MIDI] Clef % associée au synthé %".format(normalizedKey, normalizedSynth)).postln;
     };
-    ("[MIDI] Clef % associée au synthé %".format(normalizedKey, normalizedSynth)).postln;
 };
 
-~setActiveMidiSynth = { |key|
-    var normalizedKey = ~normalizeSynthKey.(key);
-    var resolvedSynth;
-    if(normalizedKey.isNil) {
-        ("[MIDI] Clef invalide %".format(key)).warn;
+~setCurrentMidiSynth = { |synthKey|
+    var normalizedSynth = ~normalizeSynthKey.(synthKey);
+    if(normalizedSynth.isNil) {
+        ("[MIDI] Synthé invalide %".format(synthKey)).warn;
         ^nil;
     };
-    resolvedSynth = ~midiSynthConfigs.includesKey(normalizedKey).if({ normalizedKey }, {
-        ~midiSynthRouting[normalizedKey]
-    });
-    if(resolvedSynth.isNil) {
-        ("[MIDI] Aucun synthé trouvé pour la clef %".format(normalizedKey)).warn;
+    if(~midiSynthLibrary.includesKey(normalizedSynth).not) {
+        ("[MIDI] Synthé inconnu %".format(synthKey)).warn;
         ^nil;
     };
-    resolvedSynth = resolvedSynth.asSymbol;
-    ~currentMidiSynthKey = resolvedSynth;
-    ~midiSynthRouting[\default] = resolvedSynth;
-    ("[MIDI] Synthé MIDI actif -> %".format(resolvedSynth)).postln;
+    ~currentMidiSynthKey = normalizedSynth;
+    ~midiSynthRouting[\default] = normalizedSynth;
+    ("[MIDI] Synthé MIDI courant -> %".format(normalizedSynth)).postln;
 };
+
+~setActiveMidiSynth = { |key| ^~setCurrentMidiSynth.(key); };
 
 ~setupMidi = {
     var matchDevice, makeKey;
@@ -109,7 +107,7 @@ if(MIDIClient.initialized.not) {
                 } {
                     synthKey = ~defaultMidiSynth;
                 };
-                config = ~midiSynthConfigs[synthKey] ?? { IdentityDictionary.new };
+                config = ~midiSynthLibrary[synthKey] ?? { IdentityDictionary.new };
                 ccParam = config[\ccParam];
                 ccMap = config[\ccMap] ?? { |val| val };
                 ccDefault = config[\ccDefault] ?? { 74 };
@@ -169,7 +167,7 @@ if(MIDIClient.initialized.not) {
                 var entryChannel = entry.tryPerform(\at, \channel);
                 var config, ccParam, ccMap;
                 if((synth.notNil) and: { entryChannel == channel }) {
-                    config = ~midiSynthConfigs[type] ?? { IdentityDictionary.new };
+                    config = ~midiSynthLibrary[type] ?? { IdentityDictionary.new };
                     ccParam = config[\ccParam];
                     ccMap = config[\ccMap] ?? { |val| val };
                     if(ccParam.notNil) {

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -48,7 +48,7 @@ SynthDef(\karplusString, {
 }).add;
 
 // Configuration des synthés MIDI disponibles et des paramètres modulables par CC
-~midiSynthConfigs = IdentityDictionary.newFrom([
+~midiSynthLibrary = IdentityDictionary.newFrom([
     \percussiveSine, (
         ccParam: \brightHz,
         ccDefault: 74, // valeur de CC "brightness" par défaut


### PR DESCRIPTION
## Summary
- centralize MIDI synth definitions in a shared library dictionary
- add a helper to update the currently selected MIDI synth used by responders
- update MIDI responders to draw configuration data from the shared library

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de6b7ee8848333a43b56d8af70cfe0