### PR TITLE
Add helper to switch current synth by key

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -2,12 +2,6 @@ if(MIDIClient.initialized.not) {
     MIDIClient.init;
 };
 
-~normalizeSynthKey = { |key|
-    if(key.isNil) { ^nil };
-    if(key.respondsTo(\asSymbol)) { ^key.asSymbol };
-    (key.isKindOf(Symbol)).if({ key }, { nil });
-};
-
 ~setMidiSynthForKey = { |key, synthKey|
     var normalizedKey = ~normalizeSynthKey.(key);
     var normalizedSynth = ~normalizeSynthKey.(synthKey);
@@ -28,18 +22,11 @@ if(MIDIClient.initialized.not) {
 };
 
 ~setCurrentMidiSynth = { |synthKey|
-    var normalizedSynth = ~normalizeSynthKey.(synthKey);
-    if(normalizedSynth.isNil) {
-        ("[MIDI] Synthé invalide %".format(synthKey)).warn;
-        ^nil;
+    var result = ~setCurrentSynth.(synthKey);
+    if(result.notNil) {
+        ("[MIDI] Synthé MIDI courant -> %".format(result)).postln;
     };
-    if(~midiSynthLibrary.includesKey(normalizedSynth).not) {
-        ("[MIDI] Synthé inconnu %".format(synthKey)).warn;
-        ^nil;
-    };
-    ~currentMidiSynthKey = normalizedSynth;
-    ~midiSynthRouting[\default] = normalizedSynth;
-    ("[MIDI] Synthé MIDI courant -> %".format(normalizedSynth)).postln;
+    result;
 };
 
 ~setActiveMidiSynth = { |key| ^~setCurrentMidiSynth.(key); };

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -71,9 +71,31 @@ SynthDef(\karplusString, {
 
 ~defaultMidiSynth = \percussiveSine;
 ~midiSynthRouting = IdentityDictionary.new;
-~midiSynthRouting[\default] = ~defaultMidiSynth;
+
+~normalizeSynthKey = ~normalizeSynthKey ?? { |key|
+    if(key.isNil) { ^nil };
+    if(key.respondsTo(\asSymbol)) { ^key.asSymbol };
+    (key.isKindOf(Symbol)).if({ key }, { nil });
+};
+
+~setCurrentSynth = { |synthKey|
+    var normalizedSynth = ~normalizeSynthKey.(synthKey);
+    if(normalizedSynth.isNil) {
+        ("[Synth] Synthé invalide %".format(synthKey)).warn;
+        ^nil;
+    };
+    if(~midiSynthLibrary.includesKey(normalizedSynth).not) {
+        ("[Synth] Synthé inconnu %".format(synthKey)).warn;
+        ^nil;
+    };
+    ~currentMidiSynthKey = normalizedSynth;
+    ~midiSynthRouting[\default] = normalizedSynth;
+    ("[Synth] Synthé courant -> %".format(normalizedSynth)).postln;
+    normalizedSynth;
+};
+
+~setCurrentSynth.(~defaultMidiSynth);
+
 ~midiSynthRouting[0] = \percussiveSine;
 ~midiSynthRouting[1] = \membraneHit;
 ~midiSynthRouting[2] = \karplusString;
-
-~currentMidiSynthKey = ~defaultMidiSynth;


### PR DESCRIPTION
## Summary
- add a `~setCurrentSynth` helper that validates synth keys against the library and updates the default routing
- reuse the helper inside the MIDI module so synth selection no longer depends on channel routing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de6dfe50948333bb61874359576a54