### PR TITLE
Fix MIDI synth selection errors

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -5,11 +5,16 @@ if(MIDIClient.initialized.not) {
 ~setMidiSynthForKey = { |key, synthKey|
     var normalizedKey = ~normalizeSynthKey.(key);
     var normalizedSynth = ~normalizeSynthKey.(synthKey);
+    var library = ~midiSynthLibrary;
     if(normalizedKey.isNil) {
         ("[MIDI] Impossible d'enregistrer le synthé : clef invalide %".format(key)).warn;
         ^nil;
     };
-    if(normalizedSynth.isNil or: { ~midiSynthLibrary.includesKey(normalizedSynth).not }) {
+    if(library.isNil) {
+        ("[MIDI] Bibliothèque de synthés MIDI indisponible").warn;
+        ^nil;
+    };
+    if(normalizedSynth.isNil or: { library.includesKey(normalizedSynth).not }) {
         ("[MIDI] Synthé inconnu %".format(synthKey)).warn;
         ^nil;
     };
@@ -30,6 +35,43 @@ if(MIDIClient.initialized.not) {
 };
 
 ~setActiveMidiSynth = { |key| ^~setCurrentMidiSynth.(key); };
+
+~getDefaultMidiSynthKey = {
+    var key = ~defaultMidiSynth ?? { \percussiveSine };
+    if(key.respondsTo(\asSymbol)) {
+        ^key.asSymbol;
+    } {
+        ^\percussiveSine;
+    };
+};
+
+~getMidiSynthSelection = { |synthKey|
+    var library = ~midiSynthLibrary;
+    var defaultKey = ~getDefaultMidiSynthKey.();
+    var resolvedKey = synthKey;
+    if(library.isNil) {
+        ("[MIDI] Bibliothèque de synthés indisponible, retour à %".format(defaultKey)).warn;
+        ^(key: defaultKey, config: IdentityDictionary.new);
+    };
+    if(resolvedKey.respondsTo(\asSymbol)) {
+        resolvedKey = resolvedKey.asSymbol;
+    } {
+        resolvedKey = defaultKey;
+    };
+    if(library.includesKey(resolvedKey).not) {
+        ("[MIDI] Synthé % introuvable, retour à %".format(resolvedKey, defaultKey)).warn;
+        resolvedKey = defaultKey;
+    };
+    (key: resolvedKey, config: library[resolvedKey] ?? { IdentityDictionary.new });
+};
+
+~getCurrentMidiSynthSelection = {
+    var key = ~currentMidiSynthKey ?? { ~midiSynthRouting.tryPerform(\at, \default) };
+    if(key.isNil) {
+        key = ~getDefaultMidiSynthKey.();
+    };
+    ~getMidiSynthSelection.(key);
+};
 
 ~setupMidi = {
     var matchDevice, makeKey;
@@ -63,7 +105,10 @@ if(MIDIClient.initialized.not) {
         }
     };
 
-    ~currentMidiSynthKey = ~currentMidiSynthKey ?? { ~midiSynthRouting[\default] ?? { ~defaultMidiSynth } };
+    {
+        var selection = ~getCurrentMidiSynthSelection.();
+        ~currentMidiSynthKey = selection[\key];
+    }.value;
 
     ~midiResponders.add(MIDIFunc.noteOn({ |velocity, note, channel, src|
         var deviceMatches = matchDevice.(src);
@@ -78,7 +123,7 @@ if(MIDIClient.initialized.not) {
                     .format(key, synth)).postln;
                 synth.tryPerform(\set, \gate, 0);
             } {
-                var freq, amp, outBus, existingEntry, existingSynth, synth, synthKey, config;
+                var freq, amp, outBus, existingEntry, existingSynth, synth, synthKey, config, selection;
                 var ccValue, args, channelCCValue, ccParam, ccDefault, ccMap, extraArgs;
                 freq = note.midicps;
                 amp = velocity.linlin(1, 127, 0.02, 0.5);
@@ -88,13 +133,10 @@ if(MIDIClient.initialized.not) {
                 ("[MIDI] stopping existing synth for key:% -> %"
                     .format(key, existingSynth)).postln;
                 existingSynth.tryPerform(\set, \gate, 0);
-                synthKey = ~midiSynthRouting[channel] ?? { ~currentMidiSynthKey ?? { ~defaultMidiSynth } };
-                if(synthKey.respondsTo(\asSymbol)) {
-                    synthKey = synthKey.asSymbol;
-                } {
-                    synthKey = ~defaultMidiSynth;
-                };
-                config = ~midiSynthLibrary[synthKey] ?? { IdentityDictionary.new };
+                selection = ~getCurrentMidiSynthSelection.();
+                synthKey = selection[\key];
+                config = selection[\config];
+                ~currentMidiSynthKey = synthKey;
                 ccParam = config[\ccParam];
                 ccMap = config[\ccMap] ?? { |val| val };
                 ccDefault = config[\ccDefault] ?? { 74 };
@@ -152,9 +194,11 @@ if(MIDIClient.initialized.not) {
                 var synth = entry.tryPerform(\at, \synth);
                 var type = entry.tryPerform(\at, \type);
                 var entryChannel = entry.tryPerform(\at, \channel);
-                var config, ccParam, ccMap;
+                var configData, config, ccParam, ccMap;
                 if((synth.notNil) and: { entryChannel == channel }) {
-                    config = ~midiSynthLibrary[type] ?? { IdentityDictionary.new };
+                    configData = ~getMidiSynthSelection.(type);
+                    config = configData[\config];
+                    entry[\type] = configData[\key];
                     ccParam = config[\ccParam];
                     ccMap = config[\ccMap] ?? { |val| val };
                     if(ccParam.notNil) {

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -20,13 +20,14 @@ SynthDef(\percussiveSine, {
 // Définition d'un synthé basé sur MembraneHexagon
 SynthDef(\membraneHit, {
     |out = 0, freq = 110, amp = 0.2, gate = 1, tension = 0.6|
-    var ampEnv = EnvGen.kr(Env.asr(0.005, 1, 1.0, curve: -4), gate, doneAction: 2);
-    var exciteEnv = EnvGen.kr(Env.perc(0.002, 0.12, 1, curve: -6), gate);
-    var excitation = PinkNoise.ar(exciteEnv) * 0.18;
-    var membrane = MembraneHexagon.ar(excitation, tension.clip(0.05, 0.99), loss: 0.9995);
-    var resonated = BPF.ar(LeakDC.ar(membrane), freq.clip(40, 4000), 0.2);
+    var ampEnv, exciteEnv, excitation, membrane, resonated, output;
+    ampEnv = EnvGen.kr(Env.asr(0.005, 1, 1.0, curve: -4), gate, doneAction: 2);
+    exciteEnv = EnvGen.kr(Env.perc(0.002, 0.12, 1, curve: -6), gate);
+    excitation = PinkNoise.ar(exciteEnv) * 0.18;
+    membrane = MembraneHexagon.ar(excitation, tension.clip(0.05, 0.99), loss: 0.9995);
+    resonated = BPF.ar(LeakDC.ar(membrane), freq.clip(40, 4000), 0.2);
     resonated = Limiter.ar(resonated, 0.7, 0.015);
-    var output = resonated * ampEnv * amp;
+    output = resonated * ampEnv * amp;
     output = Limiter.ar(output, 0.5, 0.01);
     Out.ar(out, output ! 2);
 }).add;
@@ -80,11 +81,16 @@ SynthDef(\karplusString, {
 
 ~setCurrentSynth = { |synthKey|
     var normalizedSynth = ~normalizeSynthKey.(synthKey);
+    var library = ~midiSynthLibrary;
     if(normalizedSynth.isNil) {
         ("[Synth] Synthé invalide %".format(synthKey)).warn;
         ^nil;
     };
-    if(~midiSynthLibrary.includesKey(normalizedSynth).not) {
+    if(library.isNil) {
+        ("[Synth] Bibliothèque de synthés MIDI indisponible").warn;
+        ^nil;
+    };
+    if(library.includesKey(normalizedSynth).not) {
         ("[Synth] Synthé inconnu %".format(synthKey)).warn;
         ^nil;
     };


### PR DESCRIPTION
## Summary
- guard MIDI synth registration against a missing synth library and provide helpers to resolve the active synth
- update MIDI responders to always use the current synth selection instead of per-channel routing and handle CC updates safely
- fix the membrane synth definition to declare all local variables up front for SuperCollider compatibility

## Testing
- not run (SuperCollider environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de70013d688333a96fcce5cc13a0f0