### PR TITLE
Add internal square synth and MIDI control for mixer channel

### DIFF
--- a/main.scd
+++ b/main.scd
@@ -12,9 +12,12 @@ s.options.numInputBusChannels = 8;
 // ======================
 ~bootMixTable = {
     ("modules/mixer.scd").loadRelative;
+    ("modules/synths.scd").loadRelative;
+    ("modules/midi.scd").loadRelative;
     ("modules/ui.scd").loadRelative;
 
     ~setupAudio.value;
+    if(~setupMidi.notNil) { ~setupMidi.value };
     ~createUI.value;
 };
 

--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -1,0 +1,127 @@
+// ================= Gestion MIDI =================
+
+~clearActiveMidiSynths = {
+    if(~activeMidiSynths.notNil) {
+        ~activeMidiSynths.valuesDo { |synth|
+            synth.tryPerform(\set, \gate, 0);
+            synth.tryPerform(\free);
+        };
+        ~activeMidiSynths.clear;
+    } {
+        ~activeMidiSynths = IdentityDictionary.new;
+    };
+};
+
+~setMidiRouting = { |bus, group|
+    ~midiOutputBus = bus;
+    ~midiTargetGroup = group;
+    if(~activeMidiSynths.notNil) {
+        var busIndex = if(bus.respondsTo(\index)) { bus.index } { bus ?? { 0 } };
+        ~activeMidiSynths.valuesDo { |synth|
+            synth.tryPerform(\set, \outBus, busIndex);
+            if(group.notNil) { synth.tryPerform(\moveToHead, group) };
+        };
+    };
+};
+
+~midiBusIndex = {
+    if(~midiOutputBus.notNil) {
+        if(~midiOutputBus.respondsTo(\index)) { ~midiOutputBus.index } { ~midiOutputBus };
+    } {
+        0
+    };
+};
+
+~setupMidi = {
+    [~noteOnResponder, ~noteOffResponder, ~filterCCResponder].do(_.tryPerform(\free));
+    if(~clearActiveMidiSynths.notNil) { ~clearActiveMidiSynths.value };
+
+    MIDIClient.init;
+    var endpoint = MIDIClient.findPort("TransBus", "SC1");
+    if(endpoint.notNil) {
+        MIDIIn.connect(endpoint.uid);
+        ~midiSourceID = endpoint.uid;
+    } {
+        ("Port MIDI 'TransBus'/'SC1' introuvable. Connexion à toutes les sources.").warn;
+        MIDIIn.connectAll;
+        ~midiSourceID = nil;
+    };
+
+    ~activeMidiSynths = IdentityDictionary.new;
+    var info = ~getCurrentMidiSynthInfo.value;
+    var defaults = info[\defaults] ?? { () };
+    ~currentFilterFreq = defaults[\cutoff] ?? { 1200 };
+
+    var srcID = ~midiSourceID;
+
+    ~noteOnResponder = MIDIFunc.noteOn({ |vel, note, chan, src|
+        if(srcID.isNil or: { src == srcID }) {
+            if(vel <= 0) {
+                var offKey = (chan << 7) + note;
+                var existing = ~activeMidiSynths.removeAt(offKey);
+                if(existing.notNil) { existing.tryPerform(\set, \gate, 0) };
+                ^nil;
+            };
+            var synthInfo = ~midiSynthLibrary[~currentMidiSynthKey];
+            if(synthInfo.notNil) {
+                var synthDefaults = synthInfo[\defaults] ?? { () };
+                var defName = synthInfo[\defName] ?? { ~currentMidiSynthKey };
+                var ampBase = synthDefaults[\amp] ?? { 0.3 };
+                var rq = synthDefaults[\rq] ?? { 0.2 };
+                var attack = synthDefaults[\attack] ?? { 0.01 };
+                var decay = synthDefaults[\decay] ?? { 0.2 };
+                var sustain = synthDefaults[\sustain] ?? { 0.6 };
+                var release = synthDefaults[\release] ?? { 0.4 };
+                var cutoff = ~currentFilterFreq ?? { synthDefaults[\cutoff] ?? { 1200 } };
+                var busIndex = ~midiBusIndex.value;
+                var targetGroup = ~midiTargetGroup ?? { ~sourceGroup ?? { ~inputGroup } };
+                var synth = Synth(defName, [
+                    \outBus, busIndex,
+                    \freq, note.midicps,
+                    \gate, 1,
+                    \amp, (vel / 127).clip(0, 1) * ampBase,
+                    \cutoff, cutoff,
+                    \rq, rq,
+                    \attack, attack,
+                    \decay, decay,
+                    \sustain, sustain,
+                    \release, release
+                ], target: targetGroup, addAction: \addToHead);
+                var noteKey = (chan << 7) + note;
+                ~activeMidiSynths[noteKey] = synth;
+            };
+        };
+    }, srcID: srcID);
+
+    ~noteOffResponder = MIDIFunc.noteOff({ |vel, note, chan, src|
+        if(srcID.isNil or: { src == srcID }) {
+            var key = (chan << 7) + note;
+            var synth = ~activeMidiSynths.removeAt(key);
+            if(synth.notNil) {
+                synth.tryPerform(\set, \gate, 0);
+            };
+        };
+    }, srcID: srcID);
+
+    ~filterCCResponder = MIDIFunc.cc({ |value, ccNum, chan, src|
+        if(srcID.isNil or: { src == srcID }) {
+            var synthInfo = ~midiSynthLibrary[~currentMidiSynthKey];
+            if(synthInfo.notNil) {
+                var synthDefaults = synthInfo[\defaults] ?? { () };
+                var range = synthDefaults[\cutoffRange] ?? { [200, 8000] };
+                var freq = value.linexp(0, 127, range[0], range[1]);
+                ~currentFilterFreq = freq;
+                if(~activeMidiSynths.notNil) {
+                    ~activeMidiSynths.valuesDo { |synth|
+                        synth.tryPerform(\set, \cutoff, freq);
+                    };
+                };
+            };
+        };
+    }, ccNum: 74, srcID: srcID);
+
+    CmdPeriod.doOnce({
+        [~noteOnResponder, ~noteOffResponder, ~filterCCResponder].do(_.tryPerform(\free));
+        if(~clearActiveMidiSynths.notNil) { ~clearActiveMidiSynths.value };
+    });
+};

--- a/modules/mixer.scd
+++ b/modules/mixer.scd
@@ -7,26 +7,33 @@ SynthDef(\outputLimiter, { |input = 0, out = 0|
 
 // ================= Mixage et gestion des bus =================
 
-// Définitions des tranches d'entrée : 1 (mono), 3/4, 5/6, 7/8
+// Définitions des tranches d'entrée : 1 (interne), 3/4, 5/6, 7/8
 ~mixInputs = [
-    (label: "1",     channels: [0, 0], isMono: 1),
-    (label: "3 / 4", channels: [2, 3], isMono: 0),
-    (label: "5 / 6", channels: [4, 5], isMono: 0),
-    (label: "7 / 8", channels: [6, 7], isMono: 0)
+    (label: "1",     channels: [0, 0], isMono: 1, source: \internal),
+    (label: "3 / 4", channels: [2, 3], isMono: 0, source: \hardware),
+    (label: "5 / 6", channels: [4, 5], isMono: 0, source: \hardware),
+    (label: "7 / 8", channels: [6, 7], isMono: 0, source: \hardware)
 ];
+
+// SynthDef pour router les entrées physiques vers un bus interne
+SynthDef(\mixInputRouter, {
+    |inA = 0, inB = 1, isMono = 0, outBus = 0|
+    var stereo = SoundIn.ar([inA, inB]);
+    var mono = SoundIn.ar(inA) ! 2;
+    var sig = SelectX.ar(isMono, [stereo, mono]);
+    Out.ar(outBus, sig);
+}).add;
 
 // SynthDef pour chaque tranche d'entrée avec égalisation 4 bandes
 SynthDef(\mixChannel, {
-    |inA = 0, inB = 1, isMono = 0, outBus = 0,
+    |inputBus = 0, outBus = 0,
     gainAmp = 1, mute = 0,
     lowFreq = 120, lowRQ = 1, lowGain = 0,
     mid1Freq = 500, mid1RQ = 1, mid1Gain = 0,
     mid2Freq = 2000, mid2RQ = 1, mid2Gain = 0,
     highFreq = 8000, highRQ = 1, highGain = 0|
-    var stereo, mono, sig, muteLevel;
-    stereo = SoundIn.ar([inA, inB]);
-    mono = SoundIn.ar(inA) ! 2;
-    sig = (stereo * (1 - isMono)) + (mono * isMono);
+    var sig, muteLevel;
+    sig = In.ar(inputBus, 2);
     sig = BLowShelf.ar(sig, lowFreq, lowRQ, lowGain.lag(0.1));
     sig = BPeakEQ.ar(sig, mid1Freq, mid1RQ, mid1Gain.lag(0.1));
     sig = BPeakEQ.ar(sig, mid2Freq, mid2RQ, mid2Gain.lag(0.1));
@@ -53,7 +60,7 @@ SynthDef(\mixChannel, {
 
 ~setupAudio = {
     // Nettoyage si nécessaire
-    [~channelSynths, ~limiterSynth].do { |item|
+    [~channelSynths, ~channelInputRouters, ~limiterSynth].do { |item|
         if(item.notNil) {
             if(item.isKindOf(Array)) {
                 item.do(_.tryPerform(\free));
@@ -63,7 +70,15 @@ SynthDef(\mixChannel, {
         };
     };
 
-    [~inputGroup, ~outputGroup].do(_.tryPerform(\free));
+    if(~clearActiveMidiSynths.notNil) {
+        ~clearActiveMidiSynths.value;
+    };
+
+    if(~channelInputBuses.notNil) {
+        ~channelInputBuses.do(_.tryPerform(\free));
+    };
+
+    [~sourceGroup, ~channelGroup, ~inputGroup, ~outputGroup].do(_.tryPerform(\free));
     ~mixBus.tryPerform(\free);
 
     // S'assurer que toutes les définitions de synthés précédemment envoyées
@@ -73,7 +88,11 @@ SynthDef(\mixChannel, {
     ~mixBus = Bus.audio(s, 2);
 
     ~inputGroup = Group.head(s);
+    ~sourceGroup = Group.head(~inputGroup);
+    ~channelGroup = Group.after(~sourceGroup);
     ~outputGroup = Group.after(~inputGroup);
+
+    ~channelInputBuses = ~mixInputs.collect { Bus.audio(s, 2) };
 
     ~channelStates = Array.fill(~mixInputs.size, {
         var eqState = IdentityDictionary.new;
@@ -86,9 +105,7 @@ SynthDef(\mixChannel, {
     ~channelSynths = ~mixInputs.collect { |cfg, index|
         var state = ~channelStates[index];
         Synth(\mixChannel, [
-            \inA, cfg[\channels][0],
-            \inB, cfg[\channels][1],
-            \isMono, cfg[\isMono],
+            \inputBus, ~channelInputBuses[index].index,
             \outBus, ~mixBus,
             \gainAmp, state[\gainDB].dbamp,
             \lowFreq, state[\eq][\low][\freq],
@@ -104,7 +121,24 @@ SynthDef(\mixChannel, {
             \highRQ, (state[\eq][\high][\q] ?? { 1 }).reciprocal,
             \highGain, state[\eq][\high][\gain],
             \mute, state[\muted]
-        ], target: ~inputGroup);
+        ], target: ~channelGroup, addAction: \addToTail);
+    };
+
+    ~channelInputRouters = ~mixInputs.collect { |cfg, index|
+        if((cfg[\source] ?? { \hardware }) == \hardware) {
+            Synth(\mixInputRouter, [
+                \inA, cfg[\channels][0],
+                \inB, cfg[\channels][1],
+                \isMono, cfg[\isMono],
+                \outBus, ~channelInputBuses[index].index
+            ], target: ~sourceGroup, addAction: \addToTail);
+        } {
+            nil
+        }
+    };
+
+    if(~setMidiRouting.notNil) {
+        ~setMidiRouting.value(~channelInputBuses[0], ~sourceGroup);
     };
 
     ~limiterSynth = Synth(\outputLimiter, [
@@ -156,12 +190,14 @@ SynthDef(\mixChannel, {
     };
 
     CmdPeriod.doOnce({
-        [~channelSynths, ~limiterSynth].do { |item|
+        if(~clearActiveMidiSynths.notNil) { ~clearActiveMidiSynths.value };
+        [~channelSynths, ~channelInputRouters, ~limiterSynth].do { |item|
             if(item.notNil) {
                 if(item.isKindOf(Array)) { item.do(_.tryPerform(\free)) } { item.tryPerform(\free) };
             };
         };
+        if(~channelInputBuses.notNil) { ~channelInputBuses.do(_.tryPerform(\free)) };
         [~mixBus].do { |bus| bus.tryPerform(\free) };
-        [~inputGroup, ~outputGroup].do(_.tryPerform(\free));
+        [~sourceGroup, ~channelGroup, ~inputGroup, ~outputGroup].do(_.tryPerform(\free));
     });
 };

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -1,0 +1,51 @@
+// ================= Synthés internes =================
+
+SynthDef(\squareLead, { |outBus = 0, freq = 440, gate = 1,
+    amp = 0.3, cutoff = 1200, rq = 0.2,
+    attack = 0.01, decay = 0.2, sustain = 0.6, release = 0.4|
+    var env = EnvGen.kr(Env.adsr(attack, decay, sustain, release), gate, doneAction: 2);
+    var sig = Pulse.ar(freq, 0.5);
+    sig = RLPF.ar(sig, cutoff.clip(40, 20000), rq.clip(0.05, 1));
+    sig = (sig * env * amp).dup;
+    Out.ar(outBus, sig);
+}).add;
+
+~midiSynthLibrary = IdentityDictionary.newFrom([
+    \squareLead, (
+        defName: \squareLead,
+        defaults: (
+            amp: 0.35,
+            cutoff: 1400,
+            cutoffRange: [200, 8000],
+            rq: 0.2,
+            attack: 0.01,
+            decay: 0.2,
+            sustain: 0.6,
+            release: 0.4
+        )
+    )
+]);
+
+~currentMidiSynthKey = ~currentMidiSynthKey ?? { \squareLead };
+
+~setCurrentMidiSynth = { |key|
+    var info = ~midiSynthLibrary[key];
+    if(info.notNil) {
+        ~currentMidiSynthKey = key;
+        var defaults = info[\defaults] ?? { () };
+        ~currentFilterFreq = defaults[\cutoff] ?? { ~currentFilterFreq };
+        ("Synthé MIDI courant: %".format(key)).postln;
+        if(~activeMidiSynths.notNil) {
+            var freq = ~currentFilterFreq;
+            ~activeMidiSynths.valuesDo { |synth|
+                synth.tryPerform(\set, \cutoff, freq);
+            };
+        };
+    } {
+        ("Clé de synthé inconnue: %".format(key)).warn;
+    };
+};
+
+~getCurrentMidiSynthInfo = {
+    ~midiSynthLibrary[~currentMidiSynthKey];
+};


### PR DESCRIPTION
## Summary
- add internal audio bus routing so mixer channel 1 can host an internal instrument
- implement a square-wave synth with ADSR and low-pass filter registered in a MIDI synth dictionary
- add MIDI responders for the TransBus/SC1 IAC bus, including CC74 filter modulation and synth selection helpers
- ensure the new synth and MIDI modules are loaded during boot and MIDI setup runs after audio init

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de856ac9a0833395bf9c2ad3a5e907