### PR TITLE
Fix IdentityDictionary iteration usage

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -2,7 +2,7 @@
 
 ~clearActiveMidiSynths = {
     if(~activeMidiSynths.notNil) {
-        ~activeMidiSynths.valuesDo { |synth|
+        ~activeMidiSynths.do { |_, synth|
             synth.tryPerform(\set, \gate, 0);
             synth.tryPerform(\free);
         };
@@ -18,7 +18,7 @@
     ~midiTargetGroup = group;
     if(~activeMidiSynths.notNil) {
         busIndex = if(bus.respondsTo(\index)) { bus.index } { bus ?? { 0 } };
-        ~activeMidiSynths.valuesDo { |synth|
+        ~activeMidiSynths.do { |_, synth|
             synth.tryPerform(\set, \outBus, busIndex);
             if(group.notNil) { synth.tryPerform(\moveToHead, group) };
         };
@@ -120,7 +120,7 @@
                 freq = value.linexp(0, 127, range[0], range[1]);
                 ~currentFilterFreq = freq;
                 if(~activeMidiSynths.notNil) {
-                    ~activeMidiSynths.valuesDo { |synth|
+                    ~activeMidiSynths.do { |_, synth|
                         synth.tryPerform(\set, \cutoff, freq);
                     };
                 };

--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -38,7 +38,7 @@ SynthDef(\squareLead, { |outBus = 0, freq = 440, gate = 1,
         ("Synthé MIDI courant: %".format(key)).postln;
         if(~activeMidiSynths.notNil) {
             freq = ~currentFilterFreq;
-            ~activeMidiSynths.valuesDo { |synth|
+            ~activeMidiSynths.do { |_, synth|
                 synth.tryPerform(\set, \cutoff, freq);
             };
         };


### PR DESCRIPTION
## Summary
- replace `valuesDo` usage on `IdentityDictionary` instances with `do` to iterate over active MIDI synths safely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de8a0c022483338d143de1630b5629