### PR TITLE
Fix CURRYARG errors in MIDI synth management

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -2,7 +2,7 @@
 
 ~clearActiveMidiSynths = {
     if(~activeMidiSynths.notNil) {
-        ~activeMidiSynths.do { |_, synth|
+        ~activeMidiSynths.valuesDo { |synth|
             synth.tryPerform(\set, \gate, 0);
             synth.tryPerform(\free);
         };
@@ -18,7 +18,7 @@
     ~midiTargetGroup = group;
     if(~activeMidiSynths.notNil) {
         busIndex = if(bus.respondsTo(\index)) { bus.index } { bus ?? { 0 } };
-        ~activeMidiSynths.do { |_, synth|
+        ~activeMidiSynths.valuesDo { |synth|
             synth.tryPerform(\set, \outBus, busIndex);
             if(group.notNil) { synth.tryPerform(\moveToHead, group) };
         };
@@ -120,7 +120,7 @@
                 freq = value.linexp(0, 127, range[0], range[1]);
                 ~currentFilterFreq = freq;
                 if(~activeMidiSynths.notNil) {
-                    ~activeMidiSynths.do { |_, synth|
+                    ~activeMidiSynths.valuesDo { |synth|
                         synth.tryPerform(\set, \cutoff, freq);
                     };
                 };


### PR DESCRIPTION
## Summary
- replace IdentityDictionary `do` calls with `valuesDo` to avoid passing unsupported argument lists
- ensure active MIDI synth cleanup, routing updates, and filter sweeps operate without CURRYARG syntax errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de8a9418d483339675267eae54b249