### PR TITLE
Fix MIDI dictionary iteration

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -2,7 +2,7 @@
 
 ~clearActiveMidiSynths = {
     if(~activeMidiSynths.notNil) {
-        ~activeMidiSynths.valuesDo { |synth|
+        ~activeMidiSynths.do { |key, synth|
             synth.tryPerform(\set, \gate, 0);
             synth.tryPerform(\free);
         };
@@ -18,7 +18,7 @@
     ~midiTargetGroup = group;
     if(~activeMidiSynths.notNil) {
         busIndex = if(bus.respondsTo(\index)) { bus.index } { bus ?? { 0 } };
-        ~activeMidiSynths.valuesDo { |synth|
+        ~activeMidiSynths.do { |key, synth|
             synth.tryPerform(\set, \outBus, busIndex);
             if(group.notNil) { synth.tryPerform(\moveToHead, group) };
         };
@@ -120,7 +120,7 @@
                 freq = value.linexp(0, 127, range[0], range[1]);
                 ~currentFilterFreq = freq;
                 if(~activeMidiSynths.notNil) {
-                    ~activeMidiSynths.valuesDo { |synth|
+                    ~activeMidiSynths.do { |key, synth|
                         synth.tryPerform(\set, \cutoff, freq);
                     };
                 };


### PR DESCRIPTION
## Summary
- replace IdentityDictionary valuesDo calls with standard do iteration so MIDI synth cleanup and routing execute

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de8b1612788333a098f2ed04378845