### PR TITLE
Handle missing MIDI sources before detection

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -4,14 +4,18 @@
     MIDIClient.init;
     MIDIIn.disconnectAll;
 
-    var sourceIndex = MIDIClient.sources.detectIndex { |src|
+    var sources = MIDIClient.sources;
+    if(sources.isNil) {
+        sources = Array.new;
+    };
+    var sourceIndex = sources.detectIndex { |src|
         (src.device == "TransBus") and: { src.name == "SC1" }
     };
 
     if(sourceIndex.isNil) {
         "Source MIDI 'TransBus - SC1' introuvable.".warn;
     } {
-        MIDIIn.connect(sourceIndex, MIDIClient.sources[sourceIndex]);
+        MIDIIn.connect(sourceIndex, sources[sourceIndex]);
     };
 
     MIDIIn.noteOn = { |src, chan, num, vel|


### PR DESCRIPTION
## Summary
- guard against `MIDIClient.sources` being nil before searching for the target device
- reuse the resolved sources array when connecting to the MIDI input

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de92764fbc8333a4d150ecf97b828c