### PR TITLE
Fix MIDI source detection initialization

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -1,16 +1,13 @@
 // ================= Gestion MIDI pour le synthé interne =================
 
 ~configureMidiInput = {
-    var sources = MIDIClient.sources;
+    MIDIClient.init;
+
+    var sources = MIDIClient.sources ? Array.new;
     var sourceIndex = sources.detectIndex { |src|
         (src.device == "TransBus") and: { src.name == "SC1" }
     };
 
-	if(sources.isNil) {
-        sources = Array.new;
-    };
-
-	MIDIClient.init;
     MIDIIn.disconnectAll;
 
     if(sourceIndex.isNil) {


### PR DESCRIPTION
## Summary
- initialize the MIDI client before reading available sources and fall back to an empty array
- keep MIDI connection logic intact while avoiding nil access errors

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de936ea3748333ac8d5b8cedae9640