### PR TITLE
Initialize MIDI client before querying sources

### DIFF
--- a/modules/midi.scd
+++ b/modules/midi.scd
@@ -1,13 +1,13 @@
 // ================= Gestion MIDI pour le synthé interne =================
 
 ~configureMidiInput = {
+    MIDIClient.init;
+    MIDIIn.connectAll;
+
     var sources = MIDIClient.sources ? Array.new;
     var sourceIndex = sources.detectIndex { |src|
         (src.device == "TransBus") and: { src.name == "SC1" }
     };
-
-	MIDIClient.init;
-	MIDIIn.connectAll;
 
     if(sourceIndex.isNil) {
         "Source MIDI 'TransBus - SC1' introuvable.".warn;


### PR DESCRIPTION
## Summary
- initialize the MIDI client before querying available sources
- keep connection logic intact while ensuring TransBus endpoints are detected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9511fc508333b381172cf2bf2aaf