### PR TITLE
Add audio cleanup on GUI window close

### DIFF
--- a/modules/synths.scd
+++ b/modules/synths.scd
@@ -51,8 +51,7 @@ SynthDef(\mixChannel, {
     high: (freqKey: \highFreq, gainKey: \highGain, qKey: \highRQ)
 );
 
-~setupAudio = {
-    // Nettoyage si nécessaire
+~cleanupAudio = {
     [~channelSynths, ~limiterSynth].do { |item|
         if(item.notNil) {
             if(item.isKindOf(Array)) {
@@ -65,6 +64,17 @@ SynthDef(\mixChannel, {
 
     [~inputGroup, ~outputGroup].do(_.tryPerform(\free));
     ~mixBus.tryPerform(\free);
+
+    ~channelSynths = nil;
+    ~limiterSynth = nil;
+    ~mixBus = nil;
+    ~inputGroup = nil;
+    ~outputGroup = nil;
+};
+
+~setupAudio = {
+    // Nettoyage si nécessaire
+    ~cleanupAudio.value;
 
     // S'assurer que toutes les définitions de synthés précédemment envoyées
     // ont bien été traitées par le serveur avant d'instancier de nouveaux nodes.
@@ -155,13 +165,5 @@ SynthDef(\mixChannel, {
         };
     };
 
-    CmdPeriod.doOnce({
-        [~channelSynths, ~limiterSynth].do { |item|
-            if(item.notNil) {
-                if(item.isKindOf(Array)) { item.do(_.tryPerform(\free)) } { item.tryPerform(\free) };
-            };
-        };
-        [~mixBus].do { |bus| bus.tryPerform(\free) };
-        [~inputGroup, ~outputGroup].do(_.tryPerform(\free));
-    });
+    CmdPeriod.doOnce({ ~cleanupAudio.value });
 };

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -147,6 +147,13 @@
         [control[\container], 1]
     })).margins_(10));
 
-    window.onClose = { ~mixWindow = nil; window.close };
+    window.onClose = {
+        ~mixWindow = nil;
+        {
+            ~cleanupAudio.tryPerform(\value);
+            s.quit;
+        }.fork(AppClock);
+        window.close;
+    };
     window.front;
 };


### PR DESCRIPTION
## Summary
- add a reusable `~cleanupAudio` helper to free mix table nodes, groups, and busses
- invoke the new cleanup both during setup and when cmd-period is pressed to avoid leaked resources
- update the GUI window close handler to run the audio cleanup and quit the server

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68debeaf6244833389995ac0fd717ba8