### PR TITLE
Fix TabbedView min height setting

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -73,8 +73,8 @@
         channelBottom = CompositeView(channelContainer)
             .background_(sectionColor);
 
-        effectsTabs = TabbedView(channelBottom)
-            .minHeight_(150);
+        effectsTabs = TabbedView(channelBottom);
+        effectsTabs.view.minHeight_(150);
 
         greyholeSection = effectsTabs.add("Greyhole")
             .minHeight_(140)


### PR DESCRIPTION
### Motivation
- Calling `.minHeight_` on a `TabbedView` raised a `DoesNotUnderstandError`, so the minimum height needs to be applied to the TabbedView's underlying `view` instead.

### Description
- Replace the chained call `effectsTabs = TabbedView(channelBottom).minHeight_(150)` with `effectsTabs = TabbedView(channelBottom)` followed by `effectsTabs.view.minHeight_(150)` in `modules/ui.scd`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696832c4fdf08333ad22d5b498aea15f)