### PR TITLE
Revert effects display to stacked layout

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -47,7 +47,7 @@
     channelViews = ~mixInputs.collect { |cfg, index|
         var channelContainer, gainSection, gainSlider, muteButton;
         var channelBottom, eqArea, eqControls;
-        var effectsTabs, greyholeSection, auxSection, auxSendSlider, greyholeControls, greyholeColumns;
+        var effectsSection, greyholeSection, auxSection, auxSendSlider, greyholeControls, greyholeColumns;
         var chorusSection, chorusControls, chorusColumns;
 
         channelContainer = CompositeView(channelArea)
@@ -73,18 +73,19 @@
         channelBottom = CompositeView(channelContainer)
             .background_(sectionColor);
 
-        effectsTabs = TabbedView(channelBottom);
-        effectsTabs.view.minHeight_(150);
+        effectsSection = CompositeView(channelBottom)
+            .minHeight_(150)
+            .background_(sectionColor);
 
-        greyholeSection = effectsTabs.add("Greyhole")
+        greyholeSection = CompositeView(effectsSection)
             .minHeight_(140)
             .background_(sectionColor);
 
-        chorusSection = effectsTabs.add("Chorus")
+        chorusSection = CompositeView(effectsSection)
             .minHeight_(140)
             .background_(sectionColor);
 
-        auxSection = effectsTabs.add("Send")
+        auxSection = CompositeView(effectsSection)
             .minHeight_(60)
             .background_(sectionColor);
 
@@ -231,8 +232,14 @@
             [muteButton, 0]
         ).margins_(4));
 
+        effectsSection.layout_(VLayout(6,
+            [greyholeSection, 0],
+            [chorusSection, 0],
+            [auxSection, 0]
+        ).margins_(4));
+
         channelBottom.layout_(VLayout(6,
-            [effectsTabs.view, 1],
+            [effectsSection, 1],
             [eqArea, 2]
         ).margins_(4));
 


### PR DESCRIPTION
### Motivation
- The tabbed effects area hid controls and the UI should show Greyhole, Chorus and Send simultaneously, so the effects panel is reverted to a stacked layout.

### Description
- Replace the `TabbedView` usage with a containing `CompositeView` named `effectsSection` in `modules/ui.scd` and remove `effectsTabs`.
- Make `greyholeSection`, `chorusSection`, and `auxSection` children of `effectsSection` by creating them as `CompositeView` instances instead of adding them as tabs.
- Update layout calls to use `effectsSection.layout_(VLayout(...))` and include `effectsSection` in `channelBottom.layout_` above the `eqArea`.

### Testing
- No automated tests were run because this is a UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968396e242083338505b7a49e42d190)