### PR TITLE
Reduce chorus and aux send slider heights

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -86,11 +86,14 @@
             .background_(sectionColor);
 
         auxSection = CompositeView(effectsSection)
-            .minHeight_(60)
+            .minHeight_(30)
+            .maxHeight_(32)
             .background_(sectionColor);
 
         auxSendSlider = Slider(auxSection)
             .orientation_(\horizontal)
+            .minHeight_(12)
+            .maxHeight_(12)
             .background_(sectionColor)
             .knobColor_(accentColor);
 
@@ -179,9 +182,12 @@
         chorusControls = chorusSpecs.collect { |spec|
             var container, slider, labelView;
             container = CompositeView(chorusSection)
+                .maxHeight_(24)
                 .background_(panelColor);
             slider = Slider(container)
                 .orientation_(\horizontal)
+                .minHeight_(12)
+                .maxHeight_(12)
                 .background_(sectionColor)
                 .knobColor_(accentColor);
             labelView = StaticText(container)


### PR DESCRIPTION
### Motivation
- Make horizontal chorus controls (Depth/Mix/Feedback) and the aux send slider more compact because the chorus controls were too tall and the aux send slider was oversized.

### Description
- In `modules/ui.scd` reduce `auxSection` height from `minHeight_(60)` to `minHeight_(30)` and add `maxHeight_(32)`; constrain `auxSendSlider` with `minHeight_(12)` and `maxHeight_(12)`.
- Constrain chorus control rows with `maxHeight_(24)` and set the chorus `Slider` to `minHeight_(12)` and `maxHeight_(12)` to keep depth/mix/feedback sliders compact.

### Testing
- No automated tests were run for this UI layout change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69683a7230488333a0576e8093e868a7)