### PR TITLE
Stack chorus controls vertically

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -206,22 +206,13 @@
             (container: container, slider: slider, spec: spec);
         };
 
-        chorusColumns = chorusControls.clump(2).collect { |columnControls|
-            var columnView = CompositeView(chorusSection)
-                .background_(sectionColor);
-            columnView.layout_(VLayout(2,
-                *(columnControls.collect { |control| [control[\container], 0] })
-            ).margins_(0));
-            columnView;
-        };
-
         greyholeSection.layout_(HLayout(6,
             *(greyholeColumns.collect { |column| [column, 1] })
         ).margins_(0));
 
-        chorusSection.layout_(HLayout(6,
-            *(chorusColumns.collect { |column| [column, 1] })
-        ).margins_(0));
+        chorusSection.layout_(VLayout(4,
+            *(chorusControls.collect { |control| [control[\container], 0] })
+        ).margins_(2));
 
         auxSection.layout_(VLayout(2,
             [auxSendSlider, 0]


### PR DESCRIPTION
### Motivation
- Fix the chorus control layout so the chorus sliders are stacked vertically one below another instead of arranged across multiple columns to address positioning issues.

### Description
- Remove the `chorusColumns` multi-column construction and replace the `chorusSection` layout with a single `VLayout` that iterates over `chorusControls` in `modules/ui.scd`.

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69683b1ba4988333a7540fe453dc68ae)