### PR TITLE
Add dedicated drum mix page

### DIFF
--- a/main.scd
+++ b/main.scd
@@ -10,7 +10,7 @@ s.latency = 0.01;
 s.options.outDevice = "SoundCard";
 s.options.inDevice = "SoundCard";
 s.options.numOutputBusChannels = 70;
-s.options.numInputBusChannels = 22;
+s.options.numInputBusChannels = 32;
 
 // ======================
 // Initialisation

--- a/modules/mixer.scd
+++ b/modules/mixer.scd
@@ -44,6 +44,15 @@ SynthDef(\reverbReturn, {
     (label: "1 / 2", channels: [0, 1], isMono: 0)
 ];
 
+~drumInputs = [
+    (label: "Kick 13 / 14", channels: [12, 13], isMono: 0),
+    (label: "HH1 15 / 16", channels: [14, 15], isMono: 0),
+    (label: "HH2 17 / 18", channels: [16, 17], isMono: 0),
+    (label: "Snare 19 / 20", channels: [18, 19], isMono: 0),
+    (label: "Snare 21 / 22", channels: [20, 21], isMono: 0),
+    (label: "Cymbal 23 / 24", channels: [22, 23], isMono: 0)
+];
+
 // SynthDef pour chaque tranche d'entrée avec égalisation 4 bandes
 SynthDef(\mixChannel, {
     |inA = 0, inB = 1, isMono = 0, outBus = 0, auxBus = 0,
@@ -154,7 +163,7 @@ SynthDef(\mixChannel, {
 );
 
 ~cleanupAudio = {
-    [~channelSynths, ~limiterSynth, ~masterEqSynth, ~auxOutSynth, ~stereoInputSynth, ~reverbReturnSynth, ~airpodsOutSynth].do { |item|
+    [~channelSynths, ~drumSynths, ~limiterSynth, ~masterEqSynth, ~auxOutSynth, ~stereoInputSynth, ~reverbReturnSynth, ~airpodsOutSynth].do { |item|
         if(item.notNil) {
             if(item.isKindOf(Array)) {
                 item.do(_.tryPerform(\free));
@@ -168,6 +177,7 @@ SynthDef(\mixChannel, {
     [~mixBus, ~masterBus, ~auxBus].do(_.tryPerform(\free));
 
     ~channelSynths = nil;
+    ~drumSynths = nil;
     ~limiterSynth = nil;
     ~masterEqSynth = nil;
     ~mixBus = nil;
@@ -198,6 +208,20 @@ SynthDef(\mixChannel, {
     ~outputGroup = Group.after(~fxGroup);
 
     ~channelStates = Array.fill(~mixInputs.size, {
+        var eqState = IdentityDictionary.new;
+        ~eqDefaults.keysValuesDo { |band, defaults|
+            eqState[band] = defaults.copy;
+        };
+        (
+            gainDB: 0,
+            eq: eqState,
+            muted: 0,
+            aux: 0,
+            greyhole: ~greyholeDefaults.copy
+        );
+    });
+
+    ~drumStates = Array.fill(~drumInputs.size, {
         var eqState = IdentityDictionary.new;
         ~eqDefaults.keysValuesDo { |band, defaults|
             eqState[band] = defaults.copy;
@@ -262,6 +286,48 @@ SynthDef(\mixChannel, {
         ], target: ~inputGroup);
     }; 
 
+    ~drumSynths = ~drumInputs.collect { |cfg, index|
+        var state = ~drumStates[index];
+        Synth(\mixChannel, [
+            \inA, cfg[\channels][0],
+            \inB, cfg[\channels][1],
+            \isMono, cfg[\isMono],
+            \outBus, ~mixBus,
+            \auxBus, ~auxBus,
+            \gainAmp, state[\gainDB].dbamp,
+            \chorusDepth, state[\greyhole][\chorusDepth],
+            \chorusDryWet, state[\greyhole][\chorusDryWet],
+            \chorusFeedback, state[\greyhole][\chorusFeedback],
+            \dryWet, state[\greyhole][\dryWet],
+            \ghDelayTime, state[\greyhole][\delayTime],
+            \ghDamp, state[\greyhole][\damp],
+            \ghSize, state[\greyhole][\size],
+            \ghDiff, state[\greyhole][\diff],
+            \ghFeedback, state[\greyhole][\feedback],
+            \ghModDepth, state[\greyhole][\modDepth],
+            \ghModFreq, state[\greyhole][\modFreq],
+            \ghEarlyDiff, state[\greyhole][\earlyDiff],
+            \ghSpread, state[\greyhole][\spread],
+            \lowFreq, state[\eq][\low][\freq],
+            \lowRQ, (state[\eq][\low][\q] ?? { 1 }).reciprocal,
+            \lowGain, state[\eq][\low][\gain],
+            \mid1Freq, state[\eq][\mid1][\freq],
+            \mid1RQ, (state[\eq][\mid1][\q] ?? { 1 }).reciprocal,
+            \mid1Gain, state[\eq][\mid1][\gain],
+            \mid2Freq, state[\eq][\mid2][\freq],
+            \mid2RQ, (state[\eq][\mid2][\q] ?? { 1 }).reciprocal,
+            \mid2Gain, state[\eq][\mid2][\gain],
+            \highFreq, state[\eq][\high][\freq],
+            \highRQ, (state[\eq][\high][\q] ?? { 1 }).reciprocal,
+            \highGain, state[\eq][\high][\gain],
+            \wideFreq, state[\eq][\wide][\freq],
+            \wideRQ, (state[\eq][\wide][\q] ?? { 1 }).reciprocal,
+            \wideGain, state[\eq][\wide][\gain],
+            \mute, state[\muted],
+            \auxLevel, state[\aux]
+        ], target: ~inputGroup);
+    };
+
     ~masterEqSynth = Synth(\masterEQ, [
         \inBus, ~mixBus,
         \outBus, ~masterBus,
@@ -279,8 +345,8 @@ SynthDef(\mixChannel, {
         \highGain, ~masterEqState[\high][\gain]
     ], target: ~outputGroup, addAction: \addToHead);
     ~stereoInputSynth = Synth(\stereoInput, [
-        \inA, 18,
-        \inB, 19,
+        \inA, 30,
+        \inB, 31,
         \outBus, ~masterBus,
         \gainDB, ~stereoInputState[\gainDB]
     ], target: ~inputGroup, addAction: \addToHead);
@@ -374,6 +440,80 @@ SynthDef(\mixChannel, {
         };
     };
 
+    ~setDrumGain = { |index, db|
+        if((index >= 0) and: { index < ~drumSynths.size }) {
+            var synth = ~drumSynths[index];
+            ~drumStates[index][\gainDB] = db;
+            synth.tryPerform(\set, \gainAmp, db.dbamp);
+        };
+    };
+
+    ~setDrumMute = { |index, muted|
+        if((index >= 0) and: { index < ~drumSynths.size }) {
+            var synth = ~drumSynths[index];
+            var muteValue = muted.clip(0, 1);
+            ~drumStates[index][\muted] = muteValue;
+            synth.tryPerform(\set, \mute, muteValue);
+        };
+    };
+
+    ~setDrumAux = { |index, send|
+        if((index >= 0) and: { index < ~drumSynths.size }) {
+            var synth = ~drumSynths[index];
+            var level = send.clip(0, 1);
+            ~drumStates[index][\aux] = level;
+            synth.tryPerform(\set, \auxLevel, level);
+        };
+    };
+
+    ~setDrumGreyhole = { |index, param, value|
+        if((index >= 0) and: { index < ~drumSynths.size }) {
+            var synth = ~drumSynths[index];
+            var state = ~drumStates[index][\greyhole];
+            var key = ~greyholeParamMap[param];
+            var range = ~greyholeRanges[param];
+
+            if(key.notNil and: { range.notNil } and: { value.notNil }) {
+                var clipped = value.clip(range[0], range[1]);
+                state[param] = clipped;
+                synth.tryPerform(\set, key, clipped);
+                ~drumStates[index][\greyhole] = state;
+            };
+        };
+    };
+
+    ~setDrumChorus = { |index, param, value|
+        if((index >= 0) and: { index < ~drumSynths.size }) {
+            var synth = ~drumSynths[index];
+            var state = ~drumStates[index][\greyhole];
+            var key = ~greyholeParamMap[param];
+            var range = ~greyholeRanges[param];
+
+            if(key.notNil and: { range.notNil } and: { value.notNil }) {
+                var clipped = value.clip(range[0], range[1]);
+                state[param] = clipped;
+                synth.tryPerform(\set, key, clipped);
+                ~drumStates[index][\greyhole] = state;
+            };
+        };
+    };
+
+    ~setDrumEq = { |index, band, freq, gain, q|
+        if((index >= 0) and: { index < ~drumSynths.size }) {
+            var params = ~eqParamMap[band];
+            var synth = ~drumSynths[index];
+            if(params.notNil) {
+                var rq = q.reciprocal;
+                synth.tryPerform(\set,
+                    params[\freqKey], freq,
+                    params[\gainKey], gain,
+                    params[\qKey], rq
+                );
+            };
+            ~drumStates[index][\eq][band] = (freq: freq, gain: gain, q: q);
+        };
+    };
+
     ~setMasterEq = { |band, freq, gain, q|
         var params = ~eqParamMap[band];
         if(params.notNil) {
@@ -415,6 +555,16 @@ SynthDef(\mixChannel, {
 
     ~getChannelState = { |index|
         ~channelStates[index] ?? {
+            var eqState = IdentityDictionary.new;
+            ~eqDefaults.keysValuesDo { |band, defaults|
+                eqState[band] = defaults.copy;
+            };
+            (gainDB: 0, eq: eqState, muted: 0, aux: 0, greyhole: ~greyholeDefaults.copy);
+        };
+    };
+
+    ~getDrumState = { |index|
+        ~drumStates[index] ?? {
             var eqState = IdentityDictionary.new;
             ~eqDefaults.keysValuesDo { |band, defaults|
                 eqState[band] = defaults.copy;

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -1,6 +1,7 @@
 ~createUI = {
     var window, channelArea, channelViews, masterColumn, layoutColumns;
     var effectsWindow, effectsArea, effectsViews, effectsColumns;
+    var drumWindow, drumChannelArea, drumChannelViews, drumEffectsArea, drumEffectsViews, drumColumns;
     var windowColor = Color(0.08, 0.08, 0.1);
     var panelColor = Color(0.12, 0.12, 0.16);
     var sectionColor = Color(0.18, 0.18, 0.22);
@@ -435,7 +436,7 @@
             .background_(sectionColor);
 
         returnSliders = [
-            (key: \stereoInput, label: "In 19/20", action: { |value| ~setStereoInputGain.value(value); }),
+            (key: \stereoInput, label: "In 31/32", action: { |value| ~setStereoInputGain.value(value); }),
             (key: \reverbReturn, label: "Reverb Return", action: { |value| ~setReverbReturnGain.value(value); })
         ].collect { |spec|
             var sliderContainer, sliderView, labelView;
@@ -570,12 +571,355 @@
         [effectsArea, 1]
     ).margins_(10));
 
+    if(~drumWindow.notNil) { ~drumWindow.close };
+    drumWindow = Window("MixTable - Drums", Rect(100, 1390, 1800, 600));
+    if(drumWindow.respondsTo(\resizable_)) {
+        drumWindow.resizable_(true);
+    } {
+        if(drumWindow.respondsTo(\resizable)) {
+            drumWindow.resizable = true;
+        };
+    };
+    drumWindow.view.background_(windowColor);
+    ~drumWindow = drumWindow;
+
+    drumChannelArea = CompositeView(drumWindow)
+        .background_(windowColor);
+
+    drumChannelViews = ~drumInputs.collect { |cfg, index|
+        var channelContainer, gainSection, gainSlider, muteButton;
+        var eqArea, eqControls;
+
+        channelContainer = CompositeView(drumChannelArea)
+            .minWidth_(165)
+            .background_(panelColor);
+
+        gainSection = CompositeView(channelContainer)
+            .background_(sectionColor);
+
+        gainSlider = Slider(gainSection)
+            .orientation_(\vertical)
+            .minHeight_(160)
+            .background_(panelColor)
+            .knobColor_(accentColor);
+
+        muteButton = Button(gainSection)
+            .states_([
+                ["Mute", Color.white, Color(0.2, 0.2, 0.25)],
+                ["Muted", Color.white, mutedColor]
+            ])
+            .maxHeight_(28);
+
+        eqArea = CompositeView(channelContainer)
+            .minHeight_(320)
+            .background_(sectionColor);
+
+        eqControls = eqSpecs.collect { |spec|
+            var eqContainer, sliderRow, eqSlider, qSlider, qRange;
+
+            eqContainer = CompositeView(eqArea)
+                .background_(panelColor);
+            sliderRow = CompositeView(eqContainer)
+                .background_(panelColor);
+            eqSlider = Slider2D(sliderRow)
+                .minHeight_(110)
+                .background_(sectionColor)
+                .knobColor_(accentColor);
+            qSlider = Slider(sliderRow)
+                .orientation_(\vertical)
+                .minHeight_(110)
+                .background_(sectionColor)
+                .knobColor_(accentColor);
+
+            qRange = spec[\qRange] ?? { [0.2, 10] };
+
+            sliderRow.layout_(HLayout(6,
+                [eqSlider, 1],
+                [qSlider, 0]
+            ));
+
+            eqContainer.layout_(VLayout(6,
+                [sliderRow, 1]
+            ).margins_(4));
+
+            eqSlider.action = { |view|
+                var freq = view.x.linexp(0, 1, spec[\freqRange][0], spec[\freqRange][1]);
+                var gain = view.y.linlin(0, 1, spec[\gainRange][0], spec[\gainRange][1]);
+                var q = qSlider.value.linexp(0, 1, qRange[0], qRange[1]);
+                ~setDrumEq.value(index, spec[\band], freq, gain, q);
+            };
+
+            qSlider.action = { |slider|
+                var freq = eqSlider.x.linexp(0, 1, spec[\freqRange][0], spec[\freqRange][1]);
+                var gain = eqSlider.y.linlin(0, 1, spec[\gainRange][0], spec[\gainRange][1]);
+                var q = slider.value.linexp(0, 1, qRange[0], qRange[1]);
+                ~setDrumEq.value(index, spec[\band], freq, gain, q);
+            };
+
+            (container: eqContainer, slider: eqSlider, qSlider: qSlider, qRange: qRange, spec: spec);
+        };
+
+        eqArea.layout_(VLayout(6,
+            *(eqControls.collect { |control|
+                [control[\container], 1]
+            })
+        ).margins_(4));
+
+        gainSection.layout_(VLayout(6,
+            [gainSlider, 1],
+            [muteButton, 0]
+        ).margins_(4));
+
+        channelContainer.layout_(VLayout(2,
+            [gainSection, 1],
+            [eqArea, 3]
+        ).margins_(6));
+
+        {
+            var state = ~getDrumState.value(index);
+            var gainDB = state[\gainDB] ?? { 0 };
+            var sliderValue = gainDB.linlin(-60, 20, 0, 1).clip(0, 1);
+            var isMuted = state[\muted] ?? { 0 };
+            gainSlider.value_(sliderValue);
+            muteButton.value_(isMuted);
+
+            gainSlider.action = { |sl|
+                var db = sl.value.linlin(0, 1, -60, 20);
+                ~setDrumGain.value(index, db);
+            };
+
+            muteButton.action = { |btn|
+                var muted = btn.value.clip(0, 1);
+                ~setDrumMute.value(index, muted);
+            };
+
+            eqControls.do { |control|
+                var spec = control[\spec];
+                var eqState = state[\eq][spec[\band]] ?? { ~eqDefaults[spec[\band]].copy };
+                var x = eqState[\freq].linexp(spec[\freqRange][0], spec[\freqRange][1], 0, 1).clip(0, 1);
+                var y = eqState[\gain].linlin(spec[\gainRange][0], spec[\gainRange][1], 0, 1).clip(0, 1);
+                var qValue = (eqState[\q] ?? { 1 }).clip(control[\qRange][0], control[\qRange][1]);
+                var qSliderValue = qValue.explin(control[\qRange][0], control[\qRange][1], 0, 1).clip(0, 1);
+                control[\slider].setXY(x, y);
+                control[\qSlider].value_(qSliderValue);
+            };
+        }.value;
+
+        (container: channelContainer);
+    };
+
+    drumEffectsArea = CompositeView(drumWindow)
+        .background_(windowColor);
+
+    drumEffectsViews = ~drumInputs.collect { |cfg, index|
+        var effectsContainer, headerSection, headerLabel;
+        var greyholeSection, greyholeHeader, greyholeHeaderText, greyholeControls, greyholeColumns, greyholeColumnsContainer;
+        var chorusSection, chorusHeader, chorusHeaderText, chorusControls;
+        var auxSection, auxHeaderText, auxSendSlider;
+
+        effectsContainer = CompositeView(drumEffectsArea)
+            .minWidth_(200)
+            .background_(panelColor);
+
+        headerSection = CompositeView(effectsContainer)
+            .background_(panelColor);
+        headerLabel = StaticText(headerSection)
+            .string_("Canal " ++ (cfg[\label] ?? { (index + 1).asString }))
+            .align_(\center)
+            .stringColor_(Color.white)
+            .font_(Font(Font.defaultSansFace, 12, true));
+
+        greyholeSection = CompositeView(effectsContainer)
+            .background_(sectionColor);
+        greyholeHeader = CompositeView(greyholeSection)
+            .background_(panelColor);
+        greyholeHeaderText = StaticText(greyholeHeader)
+            .string_("Greyhole / Reverb")
+            .align_(\left)
+            .stringColor_(Color.white)
+            .font_(Font(Font.defaultSansFace, 10, true));
+
+        chorusSection = CompositeView(effectsContainer)
+            .background_(sectionColor);
+        chorusHeader = CompositeView(chorusSection)
+            .background_(panelColor);
+        chorusHeaderText = StaticText(chorusHeader)
+            .string_("Chorus")
+            .align_(\left)
+            .stringColor_(Color.white)
+            .font_(Font(Font.defaultSansFace, 10, true));
+
+        auxSection = CompositeView(effectsContainer)
+            .background_(sectionColor);
+        auxHeaderText = StaticText(auxSection)
+            .string_("Aux")
+            .align_(\left)
+            .stringColor_(Color.white)
+            .font_(Font(Font.defaultSansFace, 10, true));
+
+        auxSendSlider = Slider(auxSection)
+            .orientation_(\horizontal)
+            .minHeight_(12)
+            .maxHeight_(12)
+            .background_(panelColor)
+            .knobColor_(accentColor);
+
+        greyholeControls = greyholeSpecs.collect { |spec|
+            var container, slider, labelView;
+            container = CompositeView(greyholeSection)
+                .background_(panelColor);
+            slider = Slider(container)
+                .orientation_(\horizontal)
+                .background_(sectionColor)
+                .knobColor_(accentColor);
+            labelView = StaticText(container)
+                .string_(spec[\label])
+                .align_(\left)
+                .stringColor_(Color.white)
+                .font_(Font(Font.defaultSansFace, 9));
+            container.layout_(HLayout(4,
+                [slider, 1],
+                [labelView, 0]
+            ).margins_(2));
+            slider.action = { |sl|
+                var value = sl.value.linlin(0, 1, spec[\range][0], spec[\range][1]);
+                ~setDrumGreyhole.value(index, spec[\key], value);
+            };
+            (container: container, slider: slider, spec: spec);
+        };
+
+        greyholeColumns = greyholeControls.clump(5).collect { |columnControls|
+            var columnView = CompositeView(greyholeSection)
+                .background_(sectionColor);
+            columnView.layout_(VLayout(2,
+                *(columnControls.collect { |control| [control[\container], 0] })
+            ).margins_(0));
+            columnView;
+        };
+
+        chorusControls = chorusSpecs.collect { |spec|
+            var container, slider, labelView;
+            container = CompositeView(chorusSection)
+                .maxHeight_(24)
+                .background_(panelColor);
+            slider = Slider(container)
+                .orientation_(\horizontal)
+                .minHeight_(12)
+                .maxHeight_(12)
+                .background_(sectionColor)
+                .knobColor_(accentColor);
+            labelView = StaticText(container)
+                .string_(spec[\label])
+                .align_(\left)
+                .stringColor_(Color.white)
+                .font_(Font(Font.defaultSansFace, 9));
+            container.layout_(HLayout(4,
+                [slider, 1],
+                [labelView, 0]
+            ).margins_(2));
+            slider.action = { |sl|
+                var value = sl.value.linlin(0, 1, spec[\range][0], spec[\range][1]);
+                ~setDrumChorus.value(index, spec[\key], value);
+            };
+            (container: container, slider: slider, spec: spec);
+        };
+
+        greyholeColumnsContainer = CompositeView(greyholeSection)
+            .background_(sectionColor);
+
+        greyholeHeader.layout_(HLayout(4,
+            [greyholeHeaderText, 1]
+        ).margins_(4));
+
+        greyholeColumnsContainer.layout_(HLayout(6,
+            *(greyholeColumns.collect { |column| [column, 1] })
+        ).margins_(0));
+
+        greyholeSection.layout_(VLayout(4,
+            [greyholeHeader, 0],
+            [greyholeColumnsContainer, 1]
+        ).margins_(4));
+
+        chorusHeader.layout_(HLayout(4,
+            [chorusHeaderText, 1]
+        ).margins_(4));
+
+        chorusSection.layout_(VLayout(4,
+            [chorusHeader, 0],
+            *(chorusControls.collect { |control| [control[\container], 0] })
+        ).margins_(4));
+
+        auxSection.layout_(VLayout(4,
+            [auxHeaderText, 0],
+            [auxSendSlider, 0]
+        ).margins_(4));
+
+        headerSection.layout_(VLayout(2,
+            [headerLabel, 0]
+        ).margins_(4));
+
+        effectsContainer.layout_(VLayout(6,
+            [headerSection, 0],
+            [greyholeSection, 2],
+            [chorusSection, 1],
+            [auxSection, 0]
+        ).margins_(6));
+
+        {
+            var state = ~getDrumState.value(index);
+            var auxValue = (state[\aux] ?? { 0 }).clip(0, 1);
+            var greyholeState = state[\greyhole] ?? { ~greyholeDefaults.copy };
+            auxSendSlider.value_(auxValue);
+
+            auxSendSlider.action = { |sl|
+                ~setDrumAux.value(index, sl.value.clip(0, 1));
+            };
+
+            greyholeControls.do { |control|
+                var range = control[\spec][\range];
+                var value = greyholeState[control[\spec][\key]] ?? { range[0] };
+                var normalized = value.linlin(range[0], range[1], 0, 1).clip(0, 1);
+                control[\slider].value_(normalized);
+            };
+
+            chorusControls.do { |control|
+                var range = control[\spec][\range];
+                var value = greyholeState[control[\spec][\key]] ?? { range[0] };
+                var normalized = value.linlin(range[0], range[1], 0, 1).clip(0, 1);
+                control[\slider].value_(normalized);
+            };
+        }.value;
+
+        (container: effectsContainer);
+    };
+
+    drumColumns = drumChannelViews.collect { |control|
+        [control[\container], 1]
+    };
+
+    drumChannelArea.layout_(HLayout(10,
+        *drumColumns
+    ).margins_(10));
+
+    drumEffectsArea.layout_(HLayout(10,
+        *(drumEffectsViews.collect { |control| [control[\container], 1] })
+    ).margins_(10));
+
+    drumWindow.layout_(HLayout(10,
+        [drumChannelArea, 1],
+        [drumEffectsArea, 1]
+    ).margins_(10));
+
     window.onClose = {
         ~mixWindow = nil;
         if(~effectsWindow.notNil) {
             ~effectsWindow.close;
         };
         ~effectsWindow = nil;
+        if(~drumWindow.notNil) {
+            ~drumWindow.close;
+        };
+        ~drumWindow = nil;
         {
             ~cleanupAudio.tryPerform(\value);
             s.quit;
@@ -584,4 +928,5 @@
     };
     window.front;
     effectsWindow.front;
+    drumWindow.front;
 };


### PR DESCRIPTION
### Motivation
- Provide a dedicated third UI page for drum inputs so Ableton drum machine channels can be controlled independently. 
- Route the drum inputs to specific hardware channels (kick: 13/14, hh1: 15/16, hh2: 17/18, snare1: 19/20, snare2: 21/22, cymbal: 23/24) and free previously used outputs for the main stereo return. 
- Reuse the same per-channel effects chain from the existing mix page so drums have the same Greyhole/Chorus/Aux controls.

### Description
- Added a new `~drumInputs` array and corresponding `~drumStates`/`~drumSynths` in `modules/mixer.scd` that instantiate drum channel synths mirroring the existing channel processing. 
- Implemented drum-specific control functions in `modules/mixer.scd`: `~setDrumGain`, `~setDrumMute`, `~setDrumAux`, `~setDrumGreyhole`, `~setDrumChorus`, `~setDrumEq`, and `~getDrumState`, and included `~drumSynths` in the cleanup sequence. 
- Updated global routing and configuration by increasing `s.options.numInputBusChannels` to `32` in `main.scd` and moved the stereo return input to channels `31/32` (`inA=30, inB=31`) to free the requested drum channels. 
- Added a new Drum UI window in `modules/ui.scd` (`drumWindow`) containing six channel strips (gain/mute/EQ) and an effects column per strip that reuses the same Greyhole/Chorus/Aux layout and hooks into the new `~setDrum*` APIs, and updated the return label to "In 31/32".

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976db301af88333a519965cb1aa97f1)