### PR TITLE
Add per-channel FX chain controls and Haas L/R delay params

### DIFF
--- a/modules/mixer.scd
+++ b/modules/mixer.scd
@@ -60,7 +60,7 @@ SynthDef(\mixChannel, {
     preHpfFreq = 30, preLowShelfFreq = 120, preLowShelfGain = 0,
     monoBassFreq = 120,
     autopanRate = 0.08, autopanDepth = 0.4,
-    haasDelay = 0.012, haasMix = 0.2, haasHighFreq = 700,
+    haasDelayL = 0.012, haasDelayR = 0.012, haasMix = 0.2, haasHighFreq = 700,
     allpassMix = 0.25, allpassTime = 0.012, allpassDecay = 0.1,
     ghSideBias = 0.6,
     sideHpfFreq = 150,
@@ -91,8 +91,11 @@ SynthDef(\mixChannel, {
     panLfo = SinOsc.kr(autopanRate.clip(0.01, 2), 0, autopanDepth.clip(0, 1));
     highBand = Balance2.ar(highBand[0], highBand[1], panLfo);
     haasBand = HPF.ar(highBand, haasHighFreq.clip(200, 4000));
-    haasDelayed = DelayC.ar(haasBand[1], 0.05, haasDelay.clip(0.001, 0.03));
-    haasBlend = XFade2.ar(haasBand, [haasBand[0], haasDelayed], (haasMix.clip(0, 1) * 2) - 1);
+    haasDelayed = DelayC.ar(haasBand, 0.05, [
+        haasDelayL.clip(0.001, 0.03),
+        haasDelayR.clip(0.001, 0.03)
+    ]);
+    haasBlend = XFade2.ar(haasBand, haasDelayed, (haasMix.clip(0, 1) * 2) - 1);
     highBand = (highBand - haasBand) + haasBlend;
     sig = monoLow + highBand;
     chorusDelay = SinOsc.kr([0.23, 0.27], 0, chorusDepth.clip(0, 1) * 0.02 + 0.001, 0.005)
@@ -156,6 +159,63 @@ SynthDef(\mixChannel, {
     mid2: (freqKey: \mid2Freq, gainKey: \mid2Gain, qKey: \mid2RQ),
     high: (freqKey: \highFreq, gainKey: \highGain, qKey: \highRQ),
     wide: (freqKey: \wideFreq, gainKey: \wideGain, qKey: \wideRQ)
+);
+
+~fxDefaults = (
+    preHpfFreq: 30,
+    preLowShelfFreq: 120,
+    preLowShelfGain: 0,
+    monoBassFreq: 120,
+    autopanRate: 0.08,
+    autopanDepth: 0.4,
+    haasDelayL: 0.012,
+    haasDelayR: 0.012,
+    haasMix: 0.2,
+    haasHighFreq: 700,
+    allpassMix: 0.25,
+    allpassTime: 0.012,
+    allpassDecay: 0.1,
+    ghSideBias: 0.6,
+    sideHpfFreq: 150,
+    satDrive: 0.2
+);
+
+~fxParamMap = (
+    preHpfFreq: \preHpfFreq,
+    preLowShelfFreq: \preLowShelfFreq,
+    preLowShelfGain: \preLowShelfGain,
+    monoBassFreq: \monoBassFreq,
+    autopanRate: \autopanRate,
+    autopanDepth: \autopanDepth,
+    haasDelayL: \haasDelayL,
+    haasDelayR: \haasDelayR,
+    haasMix: \haasMix,
+    haasHighFreq: \haasHighFreq,
+    allpassMix: \allpassMix,
+    allpassTime: \allpassTime,
+    allpassDecay: \allpassDecay,
+    ghSideBias: \ghSideBias,
+    sideHpfFreq: \sideHpfFreq,
+    satDrive: \satDrive
+);
+
+~fxRanges = (
+    preHpfFreq: [10, 200],
+    preLowShelfFreq: [40, 300],
+    preLowShelfGain: [-12, 12],
+    monoBassFreq: [60, 200],
+    autopanRate: [0.01, 2],
+    autopanDepth: [0, 1],
+    haasDelayL: [0.001, 0.03],
+    haasDelayR: [0.001, 0.03],
+    haasMix: [0, 1],
+    haasHighFreq: [200, 4000],
+    allpassMix: [0, 1],
+    allpassTime: [0.001, 0.03],
+    allpassDecay: [0.01, 1],
+    ghSideBias: [0, 1],
+    sideHpfFreq: [80, 300],
+    satDrive: [0, 2]
 );
 
 ~greyholeDefaults = (
@@ -261,6 +321,7 @@ SynthDef(\mixChannel, {
             eq: eqState,
             muted: 0,
             aux: 0,
+            fx: ~fxDefaults.copy,
             greyhole: ~greyholeDefaults.copy
         );
     });
@@ -275,6 +336,7 @@ SynthDef(\mixChannel, {
             eq: eqState,
             muted: 0,
             aux: 0,
+            fx: ~fxDefaults.copy,
             greyhole: ~greyholeDefaults.copy
         );
     });
@@ -290,6 +352,7 @@ SynthDef(\mixChannel, {
 
     ~channelSynths = ~mixInputs.collect { |cfg, index|
         var state = ~channelStates[index];
+        var fxState = state[\fx] ?? { ~fxDefaults.copy };
         Synth(\mixChannel, [
             \inA, cfg[\channels][0],
             \inB, cfg[\channels][1],
@@ -297,6 +360,22 @@ SynthDef(\mixChannel, {
             \outBus, ~mixBus,
             \auxBus, ~auxBus,
             \gainAmp, state[\gainDB].dbamp,
+            \preHpfFreq, fxState[\preHpfFreq],
+            \preLowShelfFreq, fxState[\preLowShelfFreq],
+            \preLowShelfGain, fxState[\preLowShelfGain],
+            \monoBassFreq, fxState[\monoBassFreq],
+            \autopanRate, fxState[\autopanRate],
+            \autopanDepth, fxState[\autopanDepth],
+            \haasDelayL, fxState[\haasDelayL],
+            \haasDelayR, fxState[\haasDelayR],
+            \haasMix, fxState[\haasMix],
+            \haasHighFreq, fxState[\haasHighFreq],
+            \allpassMix, fxState[\allpassMix],
+            \allpassTime, fxState[\allpassTime],
+            \allpassDecay, fxState[\allpassDecay],
+            \ghSideBias, fxState[\ghSideBias],
+            \sideHpfFreq, fxState[\sideHpfFreq],
+            \satDrive, fxState[\satDrive],
             \chorusDepth, state[\greyhole][\chorusDepth],
             \chorusDryWet, state[\greyhole][\chorusDryWet],
             \chorusFeedback, state[\greyhole][\chorusFeedback],
@@ -332,6 +411,7 @@ SynthDef(\mixChannel, {
 
     ~drumSynths = ~drumInputs.collect { |cfg, index|
         var state = ~drumStates[index];
+        var fxState = state[\fx] ?? { ~fxDefaults.copy };
         Synth(\mixChannel, [
             \inA, cfg[\channels][0],
             \inB, cfg[\channels][1],
@@ -339,6 +419,22 @@ SynthDef(\mixChannel, {
             \outBus, ~mixBus,
             \auxBus, ~auxBus,
             \gainAmp, state[\gainDB].dbamp,
+            \preHpfFreq, fxState[\preHpfFreq],
+            \preLowShelfFreq, fxState[\preLowShelfFreq],
+            \preLowShelfGain, fxState[\preLowShelfGain],
+            \monoBassFreq, fxState[\monoBassFreq],
+            \autopanRate, fxState[\autopanRate],
+            \autopanDepth, fxState[\autopanDepth],
+            \haasDelayL, fxState[\haasDelayL],
+            \haasDelayR, fxState[\haasDelayR],
+            \haasMix, fxState[\haasMix],
+            \haasHighFreq, fxState[\haasHighFreq],
+            \allpassMix, fxState[\allpassMix],
+            \allpassTime, fxState[\allpassTime],
+            \allpassDecay, fxState[\allpassDecay],
+            \ghSideBias, fxState[\ghSideBias],
+            \sideHpfFreq, fxState[\sideHpfFreq],
+            \satDrive, fxState[\satDrive],
             \chorusDepth, state[\greyhole][\chorusDepth],
             \chorusDryWet, state[\greyhole][\chorusDryWet],
             \chorusFeedback, state[\greyhole][\chorusFeedback],
@@ -436,6 +532,22 @@ SynthDef(\mixChannel, {
         };
     };
 
+    ~setChannelFx = { |index, param, value|
+        if((index >= 0) and: { index < ~channelSynths.size }) {
+            var synth = ~channelSynths[index];
+            var state = ~channelStates[index][\fx] ?? { ~fxDefaults.copy };
+            var key = ~fxParamMap[param];
+            var range = ~fxRanges[param];
+
+            if(key.notNil and: { range.notNil } and: { value.notNil }) {
+                var clipped = value.clip(range[0], range[1]);
+                state[param] = clipped;
+                synth.tryPerform(\set, key, clipped);
+                ~channelStates[index][\fx] = state;
+            };
+        };
+    };
+
     ~setChannelGreyhole = { |index, param, value|
         if((index >= 0) and: { index < ~channelSynths.size }) {
             var synth = ~channelSynths[index];
@@ -507,6 +619,22 @@ SynthDef(\mixChannel, {
             var level = send.clip(0, 1);
             ~drumStates[index][\aux] = level;
             synth.tryPerform(\set, \auxLevel, level);
+        };
+    };
+
+    ~setDrumFx = { |index, param, value|
+        if((index >= 0) and: { index < ~drumSynths.size }) {
+            var synth = ~drumSynths[index];
+            var state = ~drumStates[index][\fx] ?? { ~fxDefaults.copy };
+            var key = ~fxParamMap[param];
+            var range = ~fxRanges[param];
+
+            if(key.notNil and: { range.notNil } and: { value.notNil }) {
+                var clipped = value.clip(range[0], range[1]);
+                state[param] = clipped;
+                synth.tryPerform(\set, key, clipped);
+                ~drumStates[index][\fx] = state;
+            };
         };
     };
 
@@ -603,7 +731,7 @@ SynthDef(\mixChannel, {
             ~eqDefaults.keysValuesDo { |band, defaults|
                 eqState[band] = defaults.copy;
             };
-            (gainDB: 0, eq: eqState, muted: 0, aux: 0, greyhole: ~greyholeDefaults.copy);
+            (gainDB: 0, eq: eqState, muted: 0, aux: 0, fx: ~fxDefaults.copy, greyhole: ~greyholeDefaults.copy);
         };
     };
 
@@ -613,7 +741,7 @@ SynthDef(\mixChannel, {
             ~eqDefaults.keysValuesDo { |band, defaults|
                 eqState[band] = defaults.copy;
             };
-            (gainDB: 0, eq: eqState, muted: 0, aux: 0, greyhole: ~greyholeDefaults.copy);
+            (gainDB: 0, eq: eqState, muted: 0, aux: 0, fx: ~fxDefaults.copy, greyhole: ~greyholeDefaults.copy);
         };
     };
 

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -31,6 +31,24 @@
         (key: \chorusDryWet, label: "Mix", range: [0, 1]),
         (key: \chorusFeedback, label: "Feedbk", range: [0, 1])
     ];
+    var fxSpecs = [
+        (key: \preHpfFreq, label: "HPF", range: [10, 200]),
+        (key: \preLowShelfFreq, label: "LowShelf F", range: [40, 300]),
+        (key: \preLowShelfGain, label: "LowShelf G", range: [-12, 12]),
+        (key: \monoBassFreq, label: "Mono Bass", range: [60, 200]),
+        (key: \autopanRate, label: "Pan Rate", range: [0.01, 2]),
+        (key: \autopanDepth, label: "Pan Depth", range: [0, 1]),
+        (key: \haasDelayL, label: "Haas L", range: [0.001, 0.03]),
+        (key: \haasDelayR, label: "Haas R", range: [0.001, 0.03]),
+        (key: \haasMix, label: "Haas Mix", range: [0, 1]),
+        (key: \haasHighFreq, label: "Haas HPF", range: [200, 4000]),
+        (key: \allpassMix, label: "Allpass Mix", range: [0, 1]),
+        (key: \allpassTime, label: "Allpass T", range: [0.001, 0.03]),
+        (key: \allpassDecay, label: "Allpass Dec", range: [0.01, 1]),
+        (key: \ghSideBias, label: "Side Bias", range: [0, 1]),
+        (key: \sideHpfFreq, label: "Side HPF", range: [80, 300]),
+        (key: \satDrive, label: "Sat Drive", range: [0, 2])
+    ];
 
     if(~mixWindow.notNil) { ~mixWindow.close };
     if(~effectsWindow.notNil) { ~effectsWindow.close };
@@ -187,6 +205,7 @@
 
     effectsViews = ~mixInputs.collect { |cfg, index|
         var effectsContainer, headerSection, headerLabel;
+        var fxSection, fxHeader, fxHeaderText, fxControls, fxColumns, fxColumnsContainer;
         var greyholeSection, greyholeHeader, greyholeHeaderText, greyholeControls, greyholeColumns, greyholeColumnsContainer;
         var chorusSection, chorusHeader, chorusHeaderText, chorusControls;
         var auxSection, auxHeaderText, auxSendSlider;
@@ -237,6 +256,52 @@
             .maxHeight_(12)
             .background_(panelColor)
             .knobColor_(accentColor);
+
+        fxSection = CompositeView(effectsContainer)
+            .background_(sectionColor);
+        fxHeader = CompositeView(fxSection)
+            .background_(panelColor);
+        fxHeaderText = StaticText(fxHeader)
+            .string_("FX Chain")
+            .align_(\left)
+            .stringColor_(Color.white)
+            .font_(Font(Font.defaultSansFace, 10, true));
+
+        fxControls = fxSpecs.collect { |spec|
+            var container, slider, labelView;
+            container = CompositeView(fxSection)
+                .background_(panelColor);
+            slider = Slider(container)
+                .orientation_(\horizontal)
+                .background_(sectionColor)
+                .knobColor_(accentColor);
+            labelView = StaticText(container)
+                .string_(spec[\label])
+                .align_(\left)
+                .stringColor_(Color.white)
+                .font_(Font(Font.defaultSansFace, 9));
+            container.layout_(HLayout(4,
+                [slider, 1],
+                [labelView, 0]
+            ).margins_(2));
+            slider.action = { |sl|
+                var value = sl.value.linlin(0, 1, spec[\range][0], spec[\range][1]);
+                ~setChannelFx.value(index, spec[\key], value);
+            };
+            (container: container, slider: slider, spec: spec);
+        };
+
+        fxColumns = fxControls.clump(4).collect { |columnControls|
+            var columnView = CompositeView(fxSection)
+                .background_(sectionColor);
+            columnView.layout_(VLayout(2,
+                *(columnControls.collect { |control| [control[\container], 0] })
+            ).margins_(0));
+            columnView;
+        };
+
+        fxColumnsContainer = CompositeView(fxSection)
+            .background_(sectionColor);
 
         greyholeControls = greyholeSpecs.collect { |spec|
             var container, slider, labelView;
@@ -301,6 +366,19 @@
         greyholeColumnsContainer = CompositeView(greyholeSection)
             .background_(sectionColor);
 
+        fxHeader.layout_(HLayout(4,
+            [fxHeaderText, 1]
+        ).margins_(4));
+
+        fxColumnsContainer.layout_(HLayout(6,
+            *(fxColumns.collect { |column| [column, 1] })
+        ).margins_(0));
+
+        fxSection.layout_(VLayout(4,
+            [fxHeader, 0],
+            [fxColumnsContainer, 1]
+        ).margins_(4));
+
         greyholeHeader.layout_(HLayout(4,
             [greyholeHeaderText, 1]
         ).margins_(4));
@@ -334,6 +412,7 @@
 
         effectsContainer.layout_(VLayout(6,
             [headerSection, 0],
+            [fxSection, 2],
             [greyholeSection, 2],
             [chorusSection, 1],
             [auxSection, 0]
@@ -343,6 +422,7 @@
             var state = ~getChannelState.value(index);
             var auxValue = (state[\aux] ?? { 0 }).clip(0, 1);
             var greyholeState = state[\greyhole] ?? { ~greyholeDefaults.copy };
+            var fxState = state[\fx] ?? { ~fxDefaults.copy };
             auxSendSlider.value_(auxValue);
 
             auxSendSlider.action = { |sl|
@@ -359,6 +439,13 @@
             chorusControls.do { |control|
                 var range = control[\spec][\range];
                 var value = greyholeState[control[\spec][\key]] ?? { range[0] };
+                var normalized = value.linlin(range[0], range[1], 0, 1).clip(0, 1);
+                control[\slider].value_(normalized);
+            };
+
+            fxControls.do { |control|
+                var range = control[\spec][\range];
+                var value = fxState[control[\spec][\key]] ?? { range[0] };
                 var normalized = value.linlin(range[0], range[1], 0, 1).clip(0, 1);
                 control[\slider].value_(normalized);
             };
@@ -726,6 +813,7 @@
 
     drumEffectsViews = ~drumInputs.collect { |cfg, index|
         var effectsContainer, headerSection, headerLabel;
+        var fxSection, fxHeader, fxHeaderText, fxControls, fxColumns, fxColumnsContainer;
         var greyholeSection, greyholeHeader, greyholeHeaderText, greyholeControls, greyholeColumns, greyholeColumnsContainer;
         var chorusSection, chorusHeader, chorusHeaderText, chorusControls;
         var auxSection, auxHeaderText, auxSendSlider;
@@ -776,6 +864,52 @@
             .maxHeight_(12)
             .background_(panelColor)
             .knobColor_(accentColor);
+
+        fxSection = CompositeView(effectsContainer)
+            .background_(sectionColor);
+        fxHeader = CompositeView(fxSection)
+            .background_(panelColor);
+        fxHeaderText = StaticText(fxHeader)
+            .string_("FX Chain")
+            .align_(\left)
+            .stringColor_(Color.white)
+            .font_(Font(Font.defaultSansFace, 10, true));
+
+        fxControls = fxSpecs.collect { |spec|
+            var container, slider, labelView;
+            container = CompositeView(fxSection)
+                .background_(panelColor);
+            slider = Slider(container)
+                .orientation_(\horizontal)
+                .background_(sectionColor)
+                .knobColor_(accentColor);
+            labelView = StaticText(container)
+                .string_(spec[\label])
+                .align_(\left)
+                .stringColor_(Color.white)
+                .font_(Font(Font.defaultSansFace, 9));
+            container.layout_(HLayout(4,
+                [slider, 1],
+                [labelView, 0]
+            ).margins_(2));
+            slider.action = { |sl|
+                var value = sl.value.linlin(0, 1, spec[\range][0], spec[\range][1]);
+                ~setDrumFx.value(index, spec[\key], value);
+            };
+            (container: container, slider: slider, spec: spec);
+        };
+
+        fxColumns = fxControls.clump(4).collect { |columnControls|
+            var columnView = CompositeView(fxSection)
+                .background_(sectionColor);
+            columnView.layout_(VLayout(2,
+                *(columnControls.collect { |control| [control[\container], 0] })
+            ).margins_(0));
+            columnView;
+        };
+
+        fxColumnsContainer = CompositeView(fxSection)
+            .background_(sectionColor);
 
         greyholeControls = greyholeSpecs.collect { |spec|
             var container, slider, labelView;
@@ -840,6 +974,19 @@
         greyholeColumnsContainer = CompositeView(greyholeSection)
             .background_(sectionColor);
 
+        fxHeader.layout_(HLayout(4,
+            [fxHeaderText, 1]
+        ).margins_(4));
+
+        fxColumnsContainer.layout_(HLayout(6,
+            *(fxColumns.collect { |column| [column, 1] })
+        ).margins_(0));
+
+        fxSection.layout_(VLayout(4,
+            [fxHeader, 0],
+            [fxColumnsContainer, 1]
+        ).margins_(4));
+
         greyholeHeader.layout_(HLayout(4,
             [greyholeHeaderText, 1]
         ).margins_(4));
@@ -873,6 +1020,7 @@
 
         effectsContainer.layout_(VLayout(6,
             [headerSection, 0],
+            [fxSection, 2],
             [greyholeSection, 2],
             [chorusSection, 1],
             [auxSection, 0]
@@ -882,6 +1030,7 @@
             var state = ~getDrumState.value(index);
             var auxValue = (state[\aux] ?? { 0 }).clip(0, 1);
             var greyholeState = state[\greyhole] ?? { ~greyholeDefaults.copy };
+            var fxState = state[\fx] ?? { ~fxDefaults.copy };
             auxSendSlider.value_(auxValue);
 
             auxSendSlider.action = { |sl|
@@ -898,6 +1047,13 @@
             chorusControls.do { |control|
                 var range = control[\spec][\range];
                 var value = greyholeState[control[\spec][\key]] ?? { range[0] };
+                var normalized = value.linlin(range[0], range[1], 0, 1).clip(0, 1);
+                control[\slider].value_(normalized);
+            };
+
+            fxControls.do { |control|
+                var range = control[\spec][\range];
+                var value = fxState[control[\spec][\key]] ?? { range[0] };
                 var normalized = value.linlin(range[0], range[1], 0, 1).clip(0, 1);
                 control[\slider].value_(normalized);
             };


### PR DESCRIPTION
### Motivation
- Provide a complete, per-channel FX chain (pre-clean HPF/low-shelf, mono-low split, autopan, Haas, chorus, allpass decorrelation, Greyhole reverb mid/side bias, post EQ/saturation/limiter) so each existing track can be controlled independently. 
- Expose fine-grained controls requested for mixing (Haas left/right times, autopan depth/rate, etc.) from the UI so the operator can tune the full chain per strip.

### Description
- Extended `SynthDef(\\mixChannel)` with separate `haasDelayL` and `haasDelayR` parameters and changed the Haas implementation to use `DelayC` with per-channel L/R delay values. 
- Added `~fxDefaults`, `~fxParamMap` and `~fxRanges` and included `fx` state in both `~channelStates` and `~drumStates`, then wired those FX params into synth instantiation so each synth gets its per-track FX values. 
- Implemented setter functions `~setChannelFx` and `~setDrumFx` that validate/clip values using `~fxRanges` and send parameter updates to the running synths. 
- Updated the UI (`modules/ui.scd`) to add `fxSpecs` and a new "FX Chain" section for both channels and drums, added sliders for the full FX parameter list, and hooked each slider to `~setChannelFx` / `~setDrumFx` and to initialize from the stored state.

### Testing
- No automated tests were run against the audio code; changes were exercised only via static edits and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976ea954e6c83339e025d6d2f1af870)