### PR TITLE
Make FX sliders vertical in mixer UI

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -272,17 +272,18 @@
             container = CompositeView(fxSection)
                 .background_(panelColor);
             slider = Slider(container)
-                .orientation_(\horizontal)
+                .orientation_(\vertical)
+                .minHeight_(120)
                 .background_(sectionColor)
                 .knobColor_(accentColor);
             labelView = StaticText(container)
                 .string_(spec[\label])
-                .align_(\left)
+                .align_(\center)
                 .stringColor_(Color.white)
                 .font_(Font(Font.defaultSansFace, 9));
-            container.layout_(HLayout(4,
-                [slider, 1],
-                [labelView, 0]
+            container.layout_(VLayout(4,
+                [labelView, 0],
+                [slider, 1]
             ).margins_(2));
             slider.action = { |sl|
                 var value = sl.value.linlin(0, 1, spec[\range][0], spec[\range][1]);
@@ -880,17 +881,18 @@
             container = CompositeView(fxSection)
                 .background_(panelColor);
             slider = Slider(container)
-                .orientation_(\horizontal)
+                .orientation_(\vertical)
+                .minHeight_(120)
                 .background_(sectionColor)
                 .knobColor_(accentColor);
             labelView = StaticText(container)
                 .string_(spec[\label])
-                .align_(\left)
+                .align_(\center)
                 .stringColor_(Color.white)
                 .font_(Font(Font.defaultSansFace, 9));
-            container.layout_(HLayout(4,
-                [slider, 1],
-                [labelView, 0]
+            container.layout_(VLayout(4,
+                [labelView, 0],
+                [slider, 1]
             ).margins_(2));
             slider.action = { |sl|
                 var value = sl.value.linlin(0, 1, spec[\range][0], spec[\range][1]);


### PR DESCRIPTION
### Motivation
- The FX Chain sliders used a horizontal layout which consumed too much horizontal space on small screens, limiting usable area for other controls.
- Switching these controls to a vertical layout lets the UI exploit available height and improves usability for stereo/FX sections.

### Description
- Changed FX slider widgets in `modules/ui.scd` from horizontal to vertical by setting `Slider(...).orientation_(\vertical)` for both the mix and drum FX windows.
- Added a minimum height via `minHeight_(120)` to encourage the sliders to use vertical space on smaller screens.
- Centered the per-control label text with `.align_(\center)` and swapped the layout from `HLayout` to `VLayout` so labels appear above their sliders.
- Applied the same changes to both FX Chain areas (mix FX and drum FX) to keep behavior consistent.

### Testing
- No automated tests were run for this UI layout-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976f02af1908333bad6f40bb8b3b214)