### PR TITLE
Wrap fader channels into 6-wide rows

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -1,7 +1,7 @@
 ~createUI = {
-    var window, channelArea, channelViews, masterColumn, layoutColumns;
+    var window, channelArea, channelViews, masterColumn, layoutColumns, layoutRows;
     var effectsWindow, effectsArea, effectsViews, effectsColumns;
-    var drumWindow, drumChannelArea, drumChannelViews, drumColumns;
+    var drumWindow, drumChannelArea, drumChannelViews, drumColumns, drumRows;
     var drumEffectsWindow, drumEffectsArea, drumEffectsViews;
     var windowColor = Color(0.08, 0.08, 0.1);
     var panelColor = Color(0.12, 0.12, 0.16);
@@ -644,9 +644,12 @@
         [control[\container], 1]
     };
     layoutColumns = layoutColumns.add([masterColumn, 0]);
+    layoutRows = layoutColumns.clump(6).collect { |row|
+        HLayout(10, *row)
+    };
 
-    channelArea.layout_(HLayout(10,
-        *layoutColumns
+    channelArea.layout_(VLayout(10,
+        *(layoutRows.collect { |row| [row, 1] })
     ).margins_(10));
 
     window.layout_(VLayout(10,
@@ -1064,9 +1067,12 @@
     drumColumns = drumChannelViews.collect { |control|
         [control[\container], 1]
     };
+    drumRows = drumColumns.clump(6).collect { |row|
+        HLayout(10, *row)
+    };
 
-    drumChannelArea.layout_(HLayout(10,
-        *drumColumns
+    drumChannelArea.layout_(VLayout(10,
+        *(drumRows.collect { |row| [row, 1] })
     ).margins_(10));
 
     drumEffectsArea.layout_(HLayout(10,


### PR DESCRIPTION
### Motivation
- Prevent the main mix and drum UIs from becoming excessively wide by arranging channel faders into multiple rows.

### Description
- Updated `modules/ui.scd` to collect channel containers into `layoutColumns` and then group them into 6-wide `layoutRows` using `clump(6)` and `HLayout` for each row, and declared a new `layoutRows` variable.
- Replaced the single wide `HLayout` for `channelArea` with a `VLayout` that stacks the generated `HLayout` rows so faders wrap across multiple rows.
- Applied the same change for drum channels by adding `drumRows` and switching `drumChannelArea` to a `VLayout` of 6-wide `HLayout` rows.
- Small variable declaration updates to add `layoutRows` and `drumRows` to the top-level `var` list.

### Testing
- No automated tests were run because this is a UI layout-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697720df4f24833395add828041f419d)