### PR TITLE
Wrap FX sliders into multiple rows

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -239,7 +239,8 @@
 
     effectsViews = ~mixInputs.collect { |cfg, index|
         var effectsContainer, headerSection, headerLabel;
-        var fxSection, fxHeader, fxHeaderText, fxControls, fxControlsByKey, fxColumns, fxColumnsContainer;
+        var fxSection, fxHeader, fxHeaderText, fxControls, fxControlsByKey;
+        var fxColumnsContainer, fxRowCount, fxControlsPerRow, fxRows;
         var greyholeSection, greyholeHeader, greyholeHeaderText, greyholeControls, greyholeColumns, greyholeColumnsContainer;
         var chorusSection, chorusHeader, chorusHeaderText, chorusControls;
         var auxSection, auxHeaderText, auxSendSlider;
@@ -334,8 +335,19 @@
             control;
         };
 
+        fxRowCount = (fxSpecs.size / 10).ceil.max(1);
+        fxControlsPerRow = (fxSpecs.size / fxRowCount).ceil;
+
         fxColumnsContainer = CompositeView(fxSection)
             .background_(sectionColor);
+        fxRows = fxControls.clump(fxControlsPerRow).collect { |rowControls|
+            var rowView = CompositeView(fxColumnsContainer)
+                .background_(sectionColor);
+            rowView.layout_(HLayout(6,
+                *(rowControls.collect { |control| [control[\container], 0] })
+            ).margins_(0));
+            rowView;
+        };
 
         greyholeControls = greyholeSpecs.collect { |spec|
             var container, slider, labelView;
@@ -404,8 +416,8 @@
             [fxHeaderText, 1]
         ).margins_(4));
 
-        fxColumnsContainer.layout_(HLayout(6,
-            *(fxSpecs.collect { |spec| [fxControlsByKey[spec[\key]][\container], 0] })
+        fxColumnsContainer.layout_(VLayout(6,
+            *(fxRows.collect { |row| [row, 0] })
         ).margins_(0));
 
         fxSection.layout_(VLayout(4,
@@ -846,7 +858,8 @@
 
     drumEffectsViews = ~drumInputs.collect { |cfg, index|
         var effectsContainer, headerSection, headerLabel;
-        var fxSection, fxHeader, fxHeaderText, fxControls, fxControlsByKey, fxColumns, fxColumnsContainer;
+        var fxSection, fxHeader, fxHeaderText, fxControls, fxControlsByKey;
+        var fxColumnsContainer, fxRowCount, fxControlsPerRow, fxRows;
         var greyholeSection, greyholeHeader, greyholeHeaderText, greyholeControls, greyholeColumns, greyholeColumnsContainer;
         var chorusSection, chorusHeader, chorusHeaderText, chorusControls;
         var auxSection, auxHeaderText, auxSendSlider;
@@ -941,8 +954,19 @@
             control;
         };
 
+        fxRowCount = (fxSpecs.size / 10).ceil.max(1);
+        fxControlsPerRow = (fxSpecs.size / fxRowCount).ceil;
+
         fxColumnsContainer = CompositeView(fxSection)
             .background_(sectionColor);
+        fxRows = fxControls.clump(fxControlsPerRow).collect { |rowControls|
+            var rowView = CompositeView(fxColumnsContainer)
+                .background_(sectionColor);
+            rowView.layout_(HLayout(6,
+                *(rowControls.collect { |control| [control[\container], 0] })
+            ).margins_(0));
+            rowView;
+        };
 
         greyholeControls = greyholeSpecs.collect { |spec|
             var container, slider, labelView;
@@ -1011,8 +1035,8 @@
             [fxHeaderText, 1]
         ).margins_(4));
 
-        fxColumnsContainer.layout_(HLayout(6,
-            *(fxSpecs.collect { |spec| [fxControlsByKey[spec[\key]][\container], 0] })
+        fxColumnsContainer.layout_(VLayout(6,
+            *(fxRows.collect { |row| [row, 0] })
         ).margins_(0));
 
         fxSection.layout_(VLayout(4,


### PR DESCRIPTION
### Motivation
- FX controls were all placed in a single horizontal row which caused poor vertical distribution in the FX Chain panels, so sliders need to be wrapped across multiple rows forbetter layout and readability.

### Description
- Updated `modules/ui.scd` to compute row layout for FX controls and replaced the single `HLayout` of all controls with multiple rows assembled into a `VLayout` container.
- Added `fxRowCount` and `fxControlsPerRow` calculations using `fxSpecs.size` (e.g. `fxRowCount = (fxSpecs.size / 10).ceil.max(1)` and `fxControlsPerRow = (fxSpecs.size / fxRowCount).ceil`).
- Constructed `fxRows` via `fxControls.clump(fxControlsPerRow)` and layed out each row with `HLayout`, then placed those rows in `fxColumnsContainer` using `VLayout`.
- Applied the same change for both channel FX and drum FX sections in `modules/ui.scd` and removed the now-unused single-column variable.

### Testing
- No automated tests were run because this is a SuperCollider GUI layout change (UI-only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977323724b48333b553bb9113f80026)