### PR TITLE
Reserve soundcard channels 31/32 for cymbal and move stereo input to 33/34

### DIFF
--- a/main.scd
+++ b/main.scd
@@ -10,7 +10,7 @@ s.latency = 0.01;
 s.options.outDevice = "SoundCard";
 s.options.inDevice = "SoundCard";
 s.options.numOutputBusChannels = 70;
-s.options.numInputBusChannels = 32;
+s.options.numInputBusChannels = 34;
 
 // ======================
 // Initialisation

--- a/modules/mixer.scd
+++ b/modules/mixer.scd
@@ -50,7 +50,7 @@ SynthDef(\reverbReturn, {
     (label: "HH2 17 / 18", channels: [24, 25], isMono: 0),
     (label: "Snare 19 / 20", channels: [26, 27], isMono: 0),
     (label: "Snare 21 / 22", channels: [28, 29], isMono: 0),
-    (label: "Cymbal 23 / 24", channels: [30, 31], isMono: 0)
+    (label: "Cymbal 31 / 32", channels: [30, 31], isMono: 0)
 ];
 
 // SynthDef pour chaque tranche d'entrée avec égalisation 4 bandes
@@ -572,8 +572,8 @@ SynthDef(\mixChannel, {
         \highGain, ~masterEqState[\high][\gain]
     ], target: ~outputGroup, addAction: \addToHead);
     ~stereoInputSynth = Synth(\stereoInput, [
-        \inA, 30,
-        \inB, 31,
+        \inA, 32,
+        \inB, 33,
         \outBus, ~masterBus,
         \gainDB, ~stereoInputState[\gainDB]
     ], target: ~inputGroup, addAction: \addToHead);

--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -570,7 +570,7 @@
             .background_(sectionColor);
 
         returnSliders = [
-            (key: \stereoInput, label: "In 31/32", action: { |value| ~setStereoInputGain.value(value); }),
+            (key: \stereoInput, label: "In 33/34", action: { |value| ~setStereoInputGain.value(value); }),
             (key: \reverbReturn, label: "Reverb Return", action: { |value| ~setReverbReturnGain.value(value); })
         ].collect { |spec|
             var sliderContainer, sliderView, labelView;


### PR DESCRIPTION
### Motivation
- Reserve the hardware stereo pair 31/32 for the cymbal and avoid clashing with the master/stereo return by moving the stereo return to the next available card channels. 
- Ensure the server is configured to expose the additional input channels required for the new mapping.

### Description
- Increased `s.options.numInputBusChannels` from `32` to `34` in `main.scd` to allow addressing inputs 33/34. 
- Relabeled the drum input to "Cymbal 31 / 32" in `modules/mixer.scd`. 
- Reassigned the stereo input source in `modules/mixer.scd` by changing `~stereoInputSynth` to use `
 inA = 32` and `inB = 33` (corresponding to soundcard 33/34). 
- Updated the UI return slider label in `modules/ui.scd` from "In 31/32" to "In 33/34" to reflect the new mapping.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774725d2648333834270d3bb52fe01)