### PR TITLE
Show track labels above volume faders on mix and drum pages

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -101,7 +101,7 @@
         .background_(windowColor);
 
     channelViews = ~mixInputs.collect { |cfg, index|
-        var channelContainer, gainSection, gainSlider, muteButton;
+        var channelContainer, gainSection, gainLabel, gainSlider, muteButton;
         var eqArea, eqControls;
 
         channelContainer = CompositeView(channelArea)
@@ -110,6 +110,12 @@
 
         gainSection = CompositeView(channelContainer)
             .background_(sectionColor);
+
+        gainLabel = StaticText(gainSection)
+            .string_(cfg[\label] ?? { "Canal " ++ (index + 1).asString })
+            .align_(\center)
+            .stringColor_(Color.white)
+            .font_(Font(Font.defaultSansFace, 11, true));
 
         gainSlider = Slider(gainSection)
             .orientation_(\vertical)
@@ -180,6 +186,7 @@
         ).margins_(4));
 
         gainSection.layout_(VLayout(6,
+            [gainLabel, 0],
             [gainSlider, 1],
             [muteButton, 0]
         ).margins_(4));
@@ -721,7 +728,7 @@
         .background_(windowColor);
 
     drumChannelViews = ~drumInputs.collect { |cfg, index|
-        var channelContainer, gainSection, gainSlider, muteButton;
+        var channelContainer, gainSection, gainLabel, gainSlider, muteButton;
         var eqArea, eqControls;
 
         channelContainer = CompositeView(drumChannelArea)
@@ -730,6 +737,12 @@
 
         gainSection = CompositeView(channelContainer)
             .background_(sectionColor);
+
+        gainLabel = StaticText(gainSection)
+            .string_(cfg[\label] ?? { "Canal " ++ (index + 1).asString })
+            .align_(\center)
+            .stringColor_(Color.white)
+            .font_(Font(Font.defaultSansFace, 11, true));
 
         gainSlider = Slider(gainSection)
             .orientation_(\vertical)
@@ -800,6 +813,7 @@
         ).margins_(4));
 
         gainSection.layout_(VLayout(6,
+            [gainLabel, 0],
             [gainSlider, 1],
             [muteButton, 0]
         ).margins_(4));


### PR DESCRIPTION
### Motivation
- Improve channel identification by displaying each track's name above its volume fader on the mix and drums pages.
- Use the configured track label where present and a sensible fallback when not.

### Description
- Add a `StaticText` `gainLabel` above the vertical `Slider` in the mix channel strip in `modules/ui.scd`, using `cfg[\label]` or the fallback `"Canal N"` and styled with center alignment, white color, and font size 11.
- Add the same `gainLabel` to the drum channel strip in `modules/ui.scd` so drums match the mix page behavior.
- Update the `gainSection` `VLayout` to include the new label element and add the new `gainLabel` variable to the local declarations.

### Testing
- No automated tests were run for this change because it is a UI-only modification (visual verification only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978a38048988333aad6d11dfb28ce27)