### PR TITLE
Set SuperCollider recording to 48kHz 24-bit

### DIFF
--- a/main.scd
+++ b/main.scd
@@ -6,11 +6,13 @@ s.options.numBuffers = 2048;
 s.options.numWireBufs = 64;
 s.options.hardwareBufferSize = 64;
 s.options.blockSize = 64;
+s.options.sampleRate = 48000;
 s.latency = 0.01;
 s.options.outDevice = "SoundCard";
 s.options.inDevice = "SoundCard";
 s.options.numOutputBusChannels = 70;
 s.options.numInputBusChannels = 34;
+s.recSampleFormat = "int24";
 
 // ======================
 // Initialisation


### PR DESCRIPTION
### Motivation
- Ensure the SuperCollider server attempts to run at 48 kHz and record using 24-bit integer format so recordings match the requested sample rate/bit depth.

### Description
- Add `s.options.sampleRate = 48000` and `s.recSampleFormat = "int24"` to `main.scd` to configure the server sample rate and recording sample format.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69795a10bf408333944c18060fa10b4a)