### PR TITLE
Open MixTable windows in fullscreen

### DIFF
--- a/modules/ui.scd
+++ b/modules/ui.scd
@@ -4,6 +4,15 @@
     var drumWindow, drumChannelArea, drumChannelViews, drumColumns;
     var drumEffectsWindow, drumEffectsArea, drumEffectsViews;
     var windowColor = Color(0.08, 0.08, 0.1);
+    var setFullScreen = { |uiWindow|
+        if(uiWindow.respondsTo(\fullScreen_)) {
+            uiWindow.fullScreen_(true);
+        } {
+            if(uiWindow.respondsTo(\fullScreen)) {
+                uiWindow.fullScreen;
+            };
+        };
+    };
     var panelColor = Color(0.12, 0.12, 0.16);
     var sectionColor = Color(0.18, 0.18, 0.22);
     var accentColor = Color(0.35, 0.65, 0.95);
@@ -95,6 +104,7 @@
         };
     };
     window.view.background_(windowColor);
+    setFullScreen.value(window);
     ~mixWindow = window;
 
     channelArea = CompositeView(window)
@@ -239,6 +249,7 @@
         };
     };
     effectsWindow.view.background_(windowColor);
+    setFullScreen.value(effectsWindow);
     ~effectsWindow = effectsWindow;
 
     effectsArea = CompositeView(effectsWindow)
@@ -722,6 +733,7 @@
         };
     };
     drumWindow.view.background_(windowColor);
+    setFullScreen.value(drumWindow);
     ~drumWindow = drumWindow;
 
     drumChannelArea = CompositeView(drumWindow)
@@ -865,6 +877,7 @@
         };
     };
     drumEffectsWindow.view.background_(windowColor);
+    setFullScreen.value(drumEffectsWindow);
     ~drumEffectsWindow = drumEffectsWindow;
 
     drumEffectsArea = CompositeView(drumEffectsWindow)


### PR DESCRIPTION
### Motivation
- Ensure the four main UI windows open automatically in fullscreen to match the requested Mac "green" button behavior.
- Make the fullscreen activation robust by detecting available fullscreen APIs before calling them.

### Description
- Add a helper `setFullScreen` (next to `windowColor`) that calls `fullScreen_` when available and falls back to `fullScreen` when appropriate.
- Invoke `setFullScreen.value(...)` for the four windows: the main `window` (mix), `effectsWindow`, `drumWindow`, and `drumEffectsWindow` so they open fullscreen on creation.
- Preserve existing `resizable` and layout logic and only add fullscreen activation without changing other UI behavior.

### Testing
- No automated tests were executed against the modified code; the change was committed and verified by updating `modules/ui.scd`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979f91ad6a88333bf4c9ee725f0dc61)